### PR TITLE
fix: org name validation

### DIFF
--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -137,12 +137,16 @@ class CreateCommand extends Command<int> {
   }
 
   /// Gets the organization name.
-  List<String> get _orgName {
-    if (_argResults['org-name'] == null) return _defaultOrgName.split('.');
-
-    final orgName = _argResults['org-name'] as String;
+  List<Map<String, String>> get _orgName {
+    final orgName = _argResults['org-name'] as String? ?? _defaultOrgName;
     _validateOrgName(orgName);
-    return orgName.split('.');
+    final segments = orgName.replaceAll(RegExp(r'-|_'), ' ').split('.');
+    return segments.map((segment) {
+      return {
+        'value': segment,
+        'separator': segment == segments.last ? '' : '.'
+      };
+    }).toList();
   }
 
   void _validateOrgName(String name) {

--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -151,7 +151,9 @@ class CreateCommand extends Command<int> {
       throw UsageException(
         '"$name" is not a valid org name.\n\n'
         'A valid org name has at least 2 parts separated by "."\n'
-        'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
+        'Each part must start with a letter and only include '
+        'alphanumeric characters (A-Z, a-z, 0-9), underscores (_), '
+        'and hyphens (-)\n'
         '(ex. very.good.org)',
         usage,
       );

--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -18,7 +18,7 @@ const _defaultOrgName = 'com.example.verygoodcore';
 // capital letters.
 // https://dart.dev/guides/language/language-tour#important-concepts
 final RegExp _identifierRegExp = RegExp('[a-z_][a-z0-9_]*');
-final RegExp _orgNameRegExp = RegExp(r'^[a-zA-Z]\w*(\.[a-zA-Z]\w*)+$');
+final RegExp _orgNameRegExp = RegExp(r'^[a-zA-Z][\w-]*(\.[a-zA-Z][\w-]*)+$');
 
 /// A method which returns a [Future<MasonGenerator>] given a [MasonBundle].
 typedef GeneratorBuilder = Future<MasonGenerator> Function(MasonBundle);
@@ -150,10 +150,8 @@ class CreateCommand extends Command<int> {
     if (!isValidOrgName) {
       throw UsageException(
         '"$name" is not a valid org name.\n\n'
-        'A valid org name has:\n'
-        '  - At least 2 parts separated by "."\n'
-        '  - Each part must start with a letter\n'
-        '  - Only includes alphanumeric characters and underscores'
+        'A valid org name has at least 2 parts separated by "."\n'
+        'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
         '(ex. very.good.org)',
         usage,
       );

--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -141,12 +141,14 @@ class CreateCommand extends Command<int> {
     final orgName = _argResults['org-name'] as String? ?? _defaultOrgName;
     _validateOrgName(orgName);
     final segments = orgName.replaceAll(RegExp(r'-|_'), ' ').split('.');
-    return segments.map((segment) {
-      return {
-        'value': segment,
-        'separator': segment == segments.last ? '' : '.'
-      };
-    }).toList();
+    final org = <Map<String, String>>[];
+    for (var i = 0; i < segments.length; i++) {
+      final segment = segments[i];
+      org.add(
+        {'value': segment, 'separator': i == segments.length - 1 ? '' : '.'},
+      );
+    }
+    return org;
   }
 
   void _validateOrgName(String name) {

--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -18,8 +18,7 @@ const _defaultOrgName = 'com.example.verygoodcore';
 // capital letters.
 // https://dart.dev/guides/language/language-tour#important-concepts
 final RegExp _identifierRegExp = RegExp('[a-z_][a-z0-9_]*');
-final RegExp _orgNameRegExp =
-    RegExp(r'[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+');
+final RegExp _orgNameRegExp = RegExp(r'^[a-zA-Z]\w*(\.[a-zA-Z]\w*)+$');
 
 /// A method which returns a [Future<MasonGenerator>] given a [MasonBundle].
 typedef GeneratorBuilder = Future<MasonGenerator> Function(MasonBundle);
@@ -151,8 +150,10 @@ class CreateCommand extends Command<int> {
     if (!isValidOrgName) {
       throw UsageException(
         '"$name" is not a valid org name.\n\n'
-        'A valid org name has 3 parts separated by "."'
-        'and only includes alphanumeric characters and underscores'
+        'A valid org name has:\n'
+        '  - At least 2 parts separated by "."\n'
+        '  - Each part must start with a letter\n'
+        '  - Only includes alphanumeric characters and underscores'
         '(ex. very.good.org)',
         usage,
       );
@@ -171,8 +172,7 @@ class CreateCommand extends Command<int> {
   }
 
   bool _isValidOrgName(String name) {
-    final match = _orgNameRegExp.matchAsPrefix(name);
-    return match != null && match.end == name.length;
+    return _orgNameRegExp.hasMatch(name);
   }
 
   bool _isValidPackageName(String name) {

--- a/test/src/commands/create_test.dart
+++ b/test/src/commands/create_test.dart
@@ -148,9 +148,9 @@ void main() {
       group('invalid --org-name', () {
         void expectInvalidOrgName(String orgName) async {
           final expectedErrorMessage = '"$orgName" is not a valid org name.\n\n'
-        'A valid org name has at least 2 parts separated by "."\n'
-        'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
-        '(ex. very.good.org)';
+              'A valid org name has at least 2 parts separated by "."\n'
+              'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
+              '(ex. very.good.org)';
           final result = await commandRunner.run(
             ['create', '.', '--org-name', orgName],
           );

--- a/test/src/commands/create_test.dart
+++ b/test/src/commands/create_test.dart
@@ -128,7 +128,11 @@ void main() {
           ),
           vars: {
             'project_name': 'my_app',
-            'org_name': ['com', 'example', 'verygoodcore'],
+            'org_name': [
+              {'value': 'com', 'separator': '.'},
+              {'value': 'example', 'separator': '.'},
+              {'value': 'verygoodcore', 'separator': ''}
+            ],
           },
         ),
       ).called(1);
@@ -182,7 +186,10 @@ void main() {
       });
 
       group('valid --org-name', () {
-        void expectValidOrgName(String orgName) async {
+        void expectValidOrgName(
+          String orgName,
+          List<Map<String, String>> expected,
+        ) async {
           final argResults = MockArgResults();
           final generator = MockMasonGenerator();
           final command = CreateCommand(
@@ -215,10 +222,7 @@ void main() {
                   '.tmp',
                 ),
               ),
-              vars: {
-                'project_name': 'my_app',
-                'org_name': orgName.split('.'),
-              },
+              vars: {'project_name': 'my_app', 'org_name': expected},
             ),
           ).called(1);
           verify(
@@ -235,27 +239,52 @@ void main() {
         }
 
         test('alphanumeric with three parts', () async {
-          expectValidOrgName('very.good.ventures');
+          expectValidOrgName('very.good.ventures', [
+            {'value': 'very', 'separator': '.'},
+            {'value': 'good', 'separator': '.'},
+            {'value': 'ventures', 'separator': ''},
+          ]);
         });
 
         test('containing an underscore', () async {
-          expectValidOrgName('very.good.test_case');
+          expectValidOrgName('very.good.test_case', [
+            {'value': 'very', 'separator': '.'},
+            {'value': 'good', 'separator': '.'},
+            {'value': 'test case', 'separator': ''},
+          ]);
         });
 
         test('containing a hyphen', () async {
-          expectValidOrgName('very.bad.test-case');
+          expectValidOrgName('very.bad.test-case', [
+            {'value': 'very', 'separator': '.'},
+            {'value': 'bad', 'separator': '.'},
+            {'value': 'test case', 'separator': ''},
+          ]);
         });
 
         test('single character parts', () async {
-          expectValidOrgName('v.g.v');
+          expectValidOrgName('v.g.v', [
+            {'value': 'v', 'separator': '.'},
+            {'value': 'g', 'separator': '.'},
+            {'value': 'v', 'separator': ''},
+          ]);
         });
 
         test('more than three parts', () async {
-          expectValidOrgName('very.good.ventures.app.identifier');
+          expectValidOrgName('very.good.ventures.app.identifier', [
+            {'value': 'very', 'separator': '.'},
+            {'value': 'good', 'separator': '.'},
+            {'value': 'ventures', 'separator': '.'},
+            {'value': 'app', 'separator': '.'},
+            {'value': 'identifier', 'separator': ''},
+          ]);
         });
 
         test('less than three parts', () async {
-          expectValidOrgName('verygood.ventures');
+          expectValidOrgName('verygood.ventures', [
+            {'value': 'verygood', 'separator': '.'},
+            {'value': 'ventures', 'separator': ''},
+          ]);
         });
       });
     });

--- a/test/src/commands/create_test.dart
+++ b/test/src/commands/create_test.dart
@@ -148,11 +148,9 @@ void main() {
       group('invalid --org-name', () {
         void expectInvalidOrgName(String orgName) async {
           final expectedErrorMessage = '"$orgName" is not a valid org name.\n\n'
-              'A valid org name has:\n'
-              '  - At least 2 parts separated by "."\n'
-              '  - Each part must start with a letter\n'
-              '  - Only includes alphanumeric characters and underscores'
-              '(ex. very.good.org)';
+        'A valid org name has at least 2 parts separated by "."\n'
+        'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
+        '(ex. very.good.org)';
           final result = await commandRunner.run(
             ['create', '.', '--org-name', orgName],
           );
@@ -172,16 +170,12 @@ void main() {
           expectInvalidOrgName('very%.bad@.#test');
         });
 
-        test('hyphen character present', () async {
-          expectInvalidOrgName('very.bad.test-case');
-        });
-
         test('segment starts with a non-letter', () async {
           expectInvalidOrgName('very.bad.1test');
         });
 
         test('valid prefix but invalid suffix', () async {
-          expectInvalidOrgName('very.good.prefix.bad-suffix');
+          expectInvalidOrgName('very.good.prefix.bad@@suffix');
         });
       });
 
@@ -244,6 +238,10 @@ void main() {
 
         test('containing an underscore', () async {
           expectValidOrgName('very.good.test_case');
+        });
+
+        test('containing a hyphen', () async {
+          expectValidOrgName('very.bad.test-case');
         });
 
         test('single character parts', () async {

--- a/test/src/commands/create_test.dart
+++ b/test/src/commands/create_test.dart
@@ -149,7 +149,9 @@ void main() {
         void expectInvalidOrgName(String orgName) async {
           final expectedErrorMessage = '"$orgName" is not a valid org name.\n\n'
               'A valid org name has at least 2 parts separated by "."\n'
-              'Each part must start with a letter and only include alphanumeric characters (A-Z, a-z, 0-9), underscores (_), and hyphens (-)\n'
+              'Each part must start with a letter and only include '
+              'alphanumeric characters (A-Z, a-z, 0-9), underscores (_), '
+              'and hyphens (-)\n'
               '(ex. very.good.org)';
           final result = await commandRunner.run(
             ['create', '.', '--org-name', orgName],

--- a/test/src/commands/create_test.dart
+++ b/test/src/commands/create_test.dart
@@ -186,7 +186,7 @@ void main() {
       });
 
       group('valid --org-name', () {
-        void expectValidOrgName(
+        Future<void> expectValidOrgName(
           String orgName,
           List<Map<String, String>> expected,
         ) async {
@@ -207,12 +207,6 @@ void main() {
           ).thenAnswer((_) async => 62);
           final result = await command.run();
           expect(result, equals(ExitCode.success.code));
-          verify(() => logger.progress('Bootstrapping')).called(1);
-          expect(progressLogs, equals(['Generated 62 file(s)']));
-          verify(
-            () => logger.progress('Running "flutter packages get" in .tmp'),
-          ).called(1);
-          verify(() => logger.alert('Created a Very Good App! 🦄')).called(1);
           verify(
             () => generator.generate(
               any(
@@ -225,20 +219,9 @@ void main() {
               vars: {'project_name': 'my_app', 'org_name': expected},
             ),
           ).called(1);
-          verify(
-            () => analytics.sendEvent(
-              'create',
-              'generator_id',
-              label: 'generator description',
-            ),
-          ).called(1);
-          verify(
-            () => analytics.waitForLastPing(
-                timeout: VeryGoodCommandRunner.timeout),
-          ).called(1);
         }
 
-        test('alphanumeric with three parts', () async {
+        test('alphanumeric with three parts', () {
           expectValidOrgName('very.good.ventures', [
             {'value': 'very', 'separator': '.'},
             {'value': 'good', 'separator': '.'},
@@ -246,7 +229,7 @@ void main() {
           ]);
         });
 
-        test('containing an underscore', () async {
+        test('containing an underscore', () {
           expectValidOrgName('very.good.test_case', [
             {'value': 'very', 'separator': '.'},
             {'value': 'good', 'separator': '.'},
@@ -254,7 +237,7 @@ void main() {
           ]);
         });
 
-        test('containing a hyphen', () async {
+        test('containing a hyphen', () {
           expectValidOrgName('very.bad.test-case', [
             {'value': 'very', 'separator': '.'},
             {'value': 'bad', 'separator': '.'},
@@ -262,7 +245,7 @@ void main() {
           ]);
         });
 
-        test('single character parts', () async {
+        test('single character parts', () {
           expectValidOrgName('v.g.v', [
             {'value': 'v', 'separator': '.'},
             {'value': 'g', 'separator': '.'},
@@ -270,7 +253,7 @@ void main() {
           ]);
         });
 
-        test('more than three parts', () async {
+        test('more than three parts', () {
           expectValidOrgName('very.good.ventures.app.identifier', [
             {'value': 'very', 'separator': '.'},
             {'value': 'good', 'separator': '.'},
@@ -280,7 +263,7 @@ void main() {
           ]);
         });
 
-        test('less than three parts', () async {
+        test('less than three parts', () {
           expectValidOrgName('verygood.ventures', [
             {'value': 'verygood', 'separator': '.'},
             {'value': 'ventures', 'separator': ''},


### PR DESCRIPTION

## Description
When trying to use the new `--org-name` support I found that underscores were not being supported. After looking a little closer, the regex for the org name was incorrect by not enforcing that segments must start with a letter and by enforcing a min/max of three segments.

I updated the org name regex, invalid org error message, and added more tests for edge cases.

#### Sources:
- [Android rules](https://developer.android.com/studio/build/application-id)
- [iOS rules](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier#discussion)
- [Flutter android validation](https://github.com/flutter/flutter/blob/76d5e62f42dffe3aba42bba9364c4469af1ff332/packages/flutter_tools/lib/src/commands/create_base.dart#L481)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
