### PR TITLE
fix: update min Dart SDK version

### DIFF
--- a/lib/src/templates/dart_package_bundle.dart
+++ b/lib/src/templates/dart_package_bundle.dart
@@ -20,7 +20,7 @@ final dartPackageBundle = MasonBundle.fromJson({
     {
       "path": "pubspec.yaml",
       "data":
-          "bmFtZToge3twcm9qZWN0X25hbWV9fQpkZXNjcmlwdGlvbjoge3tkZXNjcmlwdGlvbn19CnZlcnNpb246IDEuMC4wKzEKcHVibGlzaF90bzogbm9uZQoKZW52aXJvbm1lbnQ6CiAgc2RrOiAiPj0yLjEyLjAgPDMuMC4wIgoKZGV2X2RlcGVuZGVuY2llczoKICB0ZXN0OiBeMS4xNy4wCiAgdmVyeV9nb29kX2FuYWx5c2lzOiBeMi4zLjA=",
+          "bmFtZToge3twcm9qZWN0X25hbWV9fQpkZXNjcmlwdGlvbjoge3tkZXNjcmlwdGlvbn19CnZlcnNpb246IDEuMC4wKzEKcHVibGlzaF90bzogbm9uZQoKZW52aXJvbm1lbnQ6CiAgc2RrOiAiPj0yLjEzLjAgPDMuMC4wIgoKZGV2X2RlcGVuZGVuY2llczoKICB0ZXN0OiBeMS4xNy4wCiAgdmVyeV9nb29kX2FuYWx5c2lzOiBeMi4zLjA=",
       "type": "text"
     },
     {


### PR DESCRIPTION
## Description

As described in #164, the applied min Dart SDK when creating a Dart package is `2.12.0`.

A simple update of the template bundle using the `2.13.0` min version closes #164.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
