### PR TITLE
docs: remove $ prefix from cli snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Very Good Command Line Interface for Dart.
 ## Installing
 
 ```sh
-$ dart pub global activate very_good_cli
+dart pub global activate very_good_cli
 ```
 
 ## Commands


### PR DESCRIPTION
GitHub uses a `clipboard-copy` button, so instead of highlighting text to copy and paste everything except the dollar sign, users can simply click the "Copy to Clipboard" button. Unfortunately, clicking this button also copies the dollar sign. Pasting this copied text into a terminal results in an error like `command not found: $`

Let's remove the dollar sign from the copyable text, and instead use another way to denote that this "code block" is meant to be run inside of a terminal.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
