### PR TITLE
docs: update --org to correct argument name --org-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Usage: very_good create <output directory>
 very_good create my_app --desc "My new Flutter app"
 
 # Create a new Flutter app named my_app with a custom org
-very_good create my_app --desc "My new Flutter app" --org "com.custom.org"
+very_good create my_app --desc "My new Flutter app" --org-name "com.custom.org"
 
 # Create a new Flutter package named my_flutter_package
 very_good create my_flutter_package -t flutter_pkg --desc "My new Flutter package"


### PR DESCRIPTION
## Description

When trying to use the cli for the first time I encountered this typo on the org argument, it should be --org-name.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
