### PR TITLE
refactor: move logger from DirectoryGeneratorTarget to MasonGenerator.generate(...)

### DIFF
--- a/lib/src/commands/create.dart
+++ b/lib/src/commands/create.dart
@@ -144,7 +144,8 @@ class CreateCommand extends Command<int> {
     final macos = _argResults['macos'] as String? ?? 'true';
     final windows = _argResults['windows'] as String? ?? 'true';
     final fileCount = await generator.generate(
-      DirectoryGeneratorTarget(outputDirectory, _logger),
+      DirectoryGeneratorTarget(outputDirectory),
+      logger: _logger,
       vars: <String, dynamic>{
         'project_name': projectName,
         'description': description,


### PR DESCRIPTION
…generate.

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
[Mason breaking](https://github.com/felangel/mason/pull/198) required to move logger to `MasonGenerator.generate(...)` instead of adding it as a parameter to `DirectoryGeneratorTarget`. This broke GitHub pipelines since the workflows are not set to a specific version. 

* Closes: #255

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
