### PR TITLE
feat(test): add `--coverage` and `--min coverage` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Run tests in a Dart or Flutter project.
 Usage: very_good test [arguments]
 -h, --help            Print this usage information.
 -r, --recursive       Run tests recursively for all nested packages.
-    --coverage        Collects the code coverage during the test.
-    --min-coverage    Sets the minimum acceptable coverage.
+    --coverage        Whether to collect coverage information.
+    --min-coverage    Whether to enforce a minimum coverage percentage.
 
 Run "very_good help" to see global options.
 ```

--- a/README.md
+++ b/README.md
@@ -154,9 +154,11 @@ very_good test -r
 ```sh
 Run tests in a Dart or Flutter project.
 
-Usage: very_good packages get [arguments]
--h, --help         Print this usage information.
--r, --recursive    Run tests recursively for all nested packages.
+Usage: very_good test [arguments]
+-h, --help            Print this usage information.
+-r, --recursive       Run tests recursively for all nested packages.
+    --coverage        Collects the code coverage during the test.
+    --min-coverage    Sets the minimum acceptable coverage.
 
 Run "very_good help" to see global options.
 ```

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:lcov_parser/lcov_parser.dart';
 import 'package:mason/mason.dart';
 import 'package:path/path.dart' as p;
 import 'package:universal_io/io.dart';

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -4,7 +4,6 @@ part of 'cli.dart';
 /// is executed without a `pubspec.yaml`.
 class PubspecNotFound implements Exception {}
 
-
 /// {@template coverage_not_met}
 /// Thrown when `flutter test ---coverage --min-coverage value`
 /// don't met the informed minimum coverage

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -5,14 +5,14 @@ part of 'cli.dart';
 class PubspecNotFound implements Exception {}
 
 /// {@template coverage_not_met}
-/// Thrown when `flutter test ---coverage --min-coverage value`
-/// don't met the informed minimum coverage
+/// Thrown when `flutter test ---coverage --min-coverage`
+/// does not meet the provided minimum coverage threshold.
 /// {@endtemplate}
 class MinCoverageNotMet implements Exception {
   /// {@macro coverage_not_met}
   const MinCoverageNotMet(this.coverage);
 
-  /// The current coverage value when this exception was thrown
+  /// The measured coverage percentage (total hits / total found * 100).
   final double coverage;
 }
 

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -4,6 +4,19 @@ part of 'cli.dart';
 /// is executed without a `pubspec.yaml`.
 class PubspecNotFound implements Exception {}
 
+
+/// {@template coverage_not_met}
+/// Thrown when `flutter test ---coverage --min-coverage value`
+/// don't met the informed minimum coverage
+/// {@endtemplate}
+class CoverageNotMet implements Exception {
+  /// {@macro coverage_not_met}
+  CoverageNotMet(this.currentCoverage);
+
+  /// The current coverage value when this exception was thrown
+  double currentCoverage;
+}
+
 /// Flutter CLI
 class Flutter {
   /// Determine whether flutter is installed.

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -18,7 +18,10 @@ class MinCoverageNotMet implements Exception {
 
 /// Thrown when `flutter test ---coverage --min-coverage value`
 /// does not generate the coverage file within the timeout threshold.
-class GenerateCoverageTimeout implements Exception {}
+class GenerateCoverageTimeout implements Exception {
+  @override
+  String toString() => 'Timed out waiting for coverage to be generated.';
+}
 
 class _CoverageMetrics {
   const _CoverageMetrics._({this.totalHits = 0, this.totalFound = 0});

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -71,17 +71,14 @@ class TestCommand extends Command<int> {
       } on PubspecNotFound catch (_) {
         _logger.err('Could not find a pubspec.yaml in $targetPath');
         return ExitCode.noInput.code;
-      } on CoverageNotMet catch (e) {
+      } on MinCoverageNotMet catch (e) {
         _logger.err(
           'Minimum coverage of $minCoverage not met, '
-          'current coverage: ${e.currentCoverage}',
+          'current coverage: ${e.coverage}',
         );
         return ExitCode.unavailable.code;
-      } on CoverageFileNotFound catch (_) {
-        _logger.err(
-          "flutter coverage didn't generated the coverage file for "
-          'some reason',
-        );
+      } on GenerateCoverageTimeout catch (_) {
+        _logger.err('Coverage could not be generated.');
         return ExitCode.unavailable.code;
       } catch (error) {
         _logger.err('$error');

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -21,12 +21,12 @@ class TestCommand extends Command<int> {
       )
       ..addFlag(
         'coverage',
-        help: 'Collects the code coverage during the test.',
+        help: 'Whether to collect coverage information.',
         negatable: false,
       )
       ..addOption(
         'min-coverage',
-        help: 'Sets the minimum acceptable coverage.',
+        help: 'Whether to enforce a minimum coverage percentage.',
       );
   }
 

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -12,12 +12,22 @@ import 'package:very_good_cli/src/cli/cli.dart';
 class TestCommand extends Command<int> {
   /// {@macro test_command}
   TestCommand({Logger? logger}) : _logger = logger ?? Logger() {
-    argParser.addFlag(
-      'recursive',
-      abbr: 'r',
-      help: 'Run tests recursively for all nested packages.',
-      negatable: false,
-    );
+    argParser
+      ..addFlag(
+        'recursive',
+        abbr: 'r',
+        help: 'Run tests recursively for all nested packages.',
+        negatable: false,
+      )
+      ..addFlag(
+        'coverage',
+        help: 'Collects the code coverage during the test.',
+        negatable: false,
+      )
+      ..addOption(
+        'min-coverage',
+        help: 'Sets the minimum acceptable coverage.',
+      );
   }
 
   final Logger _logger;
@@ -43,6 +53,10 @@ class TestCommand extends Command<int> {
     final recursive = _argResults['recursive'] as bool;
     final target = _argResults.rest.length == 1 ? _argResults.rest[0] : '.';
     final targetPath = path.normalize(Directory(target).absolute.path);
+    final collectCoverage = _argResults['coverage'] as bool;
+    final minCoverage = double.tryParse(
+      _argResults['min-coverage'] as String? ?? '',
+    );
     final isFlutterInstalled = await Flutter.installed();
     if (isFlutterInstalled) {
       try {
@@ -51,10 +65,18 @@ class TestCommand extends Command<int> {
           recursive: recursive,
           stdout: _logger.write,
           stderr: _logger.err,
+          minCoverage: minCoverage,
+          progress: _logger.progress,
         );
       } on PubspecNotFound catch (_) {
         _logger.err('Could not find a pubspec.yaml in $targetPath');
         return ExitCode.noInput.code;
+      } on CoverageNotMet catch (e) {
+        _logger.err(
+          'Minimum coverage of $minCoverage not met, '
+          'current coverage: ${e.currentCoverage}',
+        );
+        return ExitCode.unavailable.code;
       } catch (error) {
         _logger.err('$error');
         return ExitCode.unavailable.code;

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -65,8 +65,8 @@ class TestCommand extends Command<int> {
           recursive: recursive,
           stdout: _logger.write,
           stderr: _logger.err,
+          collectCoverage: collectCoverage,
           minCoverage: minCoverage,
-          progress: _logger.progress,
         );
       } on PubspecNotFound catch (_) {
         _logger.err('Could not find a pubspec.yaml in $targetPath');
@@ -75,6 +75,12 @@ class TestCommand extends Command<int> {
         _logger.err(
           'Minimum coverage of $minCoverage not met, '
           'current coverage: ${e.currentCoverage}',
+        );
+        return ExitCode.unavailable.code;
+      } on CoverageFileNotFound catch (_) {
+        _logger.err(
+          "flutter coverage didn't generated the coverage file for "
+          'some reason',
         );
         return ExitCode.unavailable.code;
       } catch (error) {

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -73,12 +73,8 @@ class TestCommand extends Command<int> {
         return ExitCode.noInput.code;
       } on MinCoverageNotMet catch (e) {
         _logger.err(
-          'Minimum coverage of $minCoverage not met, '
-          'current coverage: ${e.coverage}',
+          'Expected coverage >= "$minCoverage" but received "${e.coverage}".',
         );
-        return ExitCode.unavailable.code;
-      } on GenerateCoverageTimeout catch (_) {
-        _logger.err('Coverage could not be generated.');
         return ExitCode.unavailable.code;
       } catch (error) {
         _logger.err('$error');

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -73,7 +73,7 @@ class TestCommand extends Command<int> {
         return ExitCode.noInput.code;
       } on MinCoverageNotMet catch (e) {
         _logger.err(
-          'Expected coverage >= "$minCoverage" but received "${e.coverage}".',
+          '''Expected coverage >= ${minCoverage!.toStringAsFixed(2)}% but actual is ${e.coverage.toStringAsFixed(2)}%.''',
         );
         return ExitCode.unavailable.code;
       } catch (error) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   args: ^2.1.0
+  lcov_parser: ^0.1.2
   mason: ">=0.1.0-dev.9 <0.1.0-dev.10"
   mason_logger: ^0.1.0-dev.6
   meta: ^1.3.0

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -218,6 +218,13 @@ void main() {
         logger = MockLogger();
       });
 
+      test('GenerateCoverageTimeout toString()', () {
+        expect(
+          GenerateCoverageTimeout().toString(),
+          equals('Timed out waiting for coverage to be generated.'),
+        );
+      });
+
       test('throws when there is no pubspec.yaml', () {
         expectLater(
           Flutter.test(cwd: Directory.systemTemp.path),

--- a/test/src/commands/test_test.dart
+++ b/test/src/commands/test_test.dart
@@ -20,8 +20,10 @@ const expectedTestUsage = [
   'Run tests in a Dart or Flutter project.\n'
       '\n'
       'Usage: very_good test [arguments]\n'
-      '-h, --help         Print this usage information.\n'
-      '-r, --recursive    Run tests recursively for all nested packages.\n'
+      '-h, --help            Print this usage information.\n'
+      '-r, --recursive       Run tests recursively for all nested packages.\n'
+      '    --coverage        Collects the code coverage during the test.\n'
+      '    --min-coverage    Sets the minimum acceptable coverage.\n'
       '\n'
       'Run "very_good help" to see global options.',
 ];

--- a/test/src/commands/test_test.dart
+++ b/test/src/commands/test_test.dart
@@ -22,8 +22,8 @@ const expectedTestUsage = [
       'Usage: very_good test [arguments]\n'
       '-h, --help            Print this usage information.\n'
       '-r, --recursive       Run tests recursively for all nested packages.\n'
-      '    --coverage        Collects the code coverage during the test.\n'
-      '    --min-coverage    Sets the minimum acceptable coverage.\n'
+      '    --coverage        Whether to collect coverage information.\n'
+      '''    --min-coverage    Whether to enforce a minimum coverage percentage.\n'''
       '\n'
       'Run "very_good help" to see global options.',
 ];

--- a/test/src/commands/test_test.dart
+++ b/test/src/commands/test_test.dart
@@ -133,6 +133,90 @@ void main() {
     );
 
     test(
+      'completes normally --coverage',
+      withRunner((commandRunner, logger, printLogs) async {
+        final directory = Directory.systemTemp.createTempSync();
+        final testDirectory = Directory(path.join(directory.path, 'test'))
+          ..createSync();
+        File(
+          path.join(directory.path, 'pubspec.yaml'),
+        ).writeAsStringSync(pubspecContent());
+        File(
+          path.join(testDirectory.path, 'example_test.dart'),
+        ).writeAsStringSync(testContent);
+        final result = await commandRunner.run(
+          ['test', '--coverage', directory.path],
+        );
+        expect(result, equals(ExitCode.success.code));
+        verify(() {
+          logger.write(
+            any(that: contains('Running "flutter test" in')),
+          );
+        }).called(1);
+        verify(() {
+          logger.write(any(that: contains('All tests passed')));
+        }).called(1);
+      }),
+    );
+
+    test(
+      'completes normally --coverage --min-coverage 0',
+      withRunner((commandRunner, logger, printLogs) async {
+        final directory = Directory.systemTemp.createTempSync();
+        final testDirectory = Directory(path.join(directory.path, 'test'))
+          ..createSync();
+        File(
+          path.join(directory.path, 'pubspec.yaml'),
+        ).writeAsStringSync(pubspecContent());
+        File(
+          path.join(testDirectory.path, 'example_test.dart'),
+        ).writeAsStringSync(testContent);
+        final result = await commandRunner.run(
+          ['test', '--coverage', '--min-coverage', '0', directory.path],
+        );
+        expect(result, equals(ExitCode.success.code));
+        verify(() {
+          logger.write(
+            any(that: contains('Running "flutter test" in')),
+          );
+        }).called(1);
+        verify(() {
+          logger.write(any(that: contains('All tests passed')));
+        }).called(1);
+      }),
+    );
+
+    test(
+      'fails when coverage not met --coverage --min-coverage 100',
+      withRunner((commandRunner, logger, printLogs) async {
+        final directory = Directory.systemTemp.createTempSync();
+        final testDirectory = Directory(path.join(directory.path, 'test'))
+          ..createSync();
+        File(
+          path.join(directory.path, 'pubspec.yaml'),
+        ).writeAsStringSync(pubspecContent());
+        File(
+          path.join(testDirectory.path, 'example_test.dart'),
+        ).writeAsStringSync(testContent);
+        final result = await commandRunner.run(
+          ['test', '--coverage', '--min-coverage', '100', directory.path],
+        );
+        expect(result, equals(ExitCode.unavailable.code));
+        verify(() {
+          logger.write(
+            any(that: contains('Running "flutter test" in')),
+          );
+        }).called(1);
+        verify(() {
+          logger.write(any(that: contains('All tests passed')));
+        }).called(1);
+        verify(
+          () => logger.err('Expected coverage >= "100.0" but received "0.0".'),
+        ).called(1);
+      }),
+    );
+
+    test(
       'completes normally '
       'when pubspec.yaml and tests exist (recursive)',
       withRunner((commandRunner, logger, printLogs) async {

--- a/test/src/commands/test_test.dart
+++ b/test/src/commands/test_test.dart
@@ -211,7 +211,7 @@ void main() {
           logger.write(any(that: contains('All tests passed')));
         }).called(1);
         verify(
-          () => logger.err('Expected coverage >= "100.0" but received "0.0".'),
+          () => logger.err('Expected coverage >= 100.00% but actual is 0.00%.'),
         ).called(1);
       }),
     );


### PR DESCRIPTION
## Description

Adds the `--coverage` and `--min-coverage` options to the `test` command

Part of #279 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
