### PR TITLE
fix: add .fvm to ignored directories for pubspec files searching

### DIFF
--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -65,6 +65,7 @@ const _ignoredDirectories = {
   '.plugin_symlinks',
   '.dart_tool',
   'build',
+  '.fvm',
 };
 
 bool _isPubspec(FileSystemEntity entity) {

--- a/test/src/commands/packages_test.dart
+++ b/test/src/commands/packages_test.dart
@@ -121,6 +121,31 @@ void main() {
       );
 
       test(
+        'ignores .fvm directory',
+        withRunner((commandRunner, logger, printLogs) async {
+          final tempDirectory = Directory.systemTemp.createTempSync();
+          final directory = Directory(path.join(tempDirectory.path, '.fvm'))
+            ..createSync();
+          File(path.join(directory.path, 'pubspec.yaml')).writeAsStringSync(
+            '''
+          name: example
+          version: 0.1.0
+          
+          environment:
+            sdk: ">=2.12.0 <3.0.0"
+          ''',
+          );
+          final result = await commandRunner.run(
+            ['packages', 'get', '-r', tempDirectory.path],
+          );
+          expect(result, equals(ExitCode.noInput.code));
+          verify(() {
+            logger.err(any(that: contains('Could not find a pubspec.yaml in')));
+          }).called(1);
+        }),
+      );
+
+      test(
         'completes normally '
         'when pubspec.yaml exists',
         withRunner((commandRunner, logger, printLogs) async {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Add `.fvm` to ignored directories to avoid `packages get --recursive` command being run for all packages inside `.fvm` folder.

Fixes: #306 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
