### PR TITLE
feat: adding exclude coverage flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ very_good test -r
 Run tests in a Dart or Flutter project.
 
 Usage: very_good test [arguments]
--h, --help            Print this usage information.
--r, --recursive       Run tests recursively for all nested packages.
-    --coverage        Whether to collect coverage information.
-    --min-coverage    Whether to enforce a minimum coverage percentage.
--x, --exclude-tags    Run only tests that do not have the specified tags.
+-h, --help                Print this usage information.
+-r, --recursive           Run tests recursively for all nested packages.
+    --coverage            Whether to collect coverage information.
+    --min-coverage        Whether to enforce a minimum coverage percentage.
+    --exclude-coverage    A glob which will be used to exclude files that match from the coverage.
+-x, --exclude-tags        Run only tests that do not have the specified tags.
 
 Run "very_good help" to see global options.
 ```

--- a/lib/src/cli/cli.dart
+++ b/lib/src/cli/cli.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:glob/glob.dart';
 import 'package:lcov_parser/lcov_parser.dart';
 import 'package:mason/mason.dart';
 import 'package:path/path.dart' as p;

--- a/lib/src/commands/test.dart
+++ b/lib/src/commands/test.dart
@@ -29,6 +29,11 @@ class TestCommand extends Command<int> {
         help: 'Whether to enforce a minimum coverage percentage.',
       )
       ..addOption(
+        'exclude-coverage',
+        help: 'A glob which will be used to exclude files that match from the '
+            'coverage.',
+      )
+      ..addOption(
         'exclude-tags',
         abbr: 'x',
         help: 'Run only tests that do not have the specified tags.',
@@ -59,6 +64,9 @@ class TestCommand extends Command<int> {
     );
     final excludeTags = _argResults['exclude-tags'] as String?;
     final isFlutterInstalled = await Flutter.installed();
+
+    final excludeFromCoverage = _argResults['exclude-coverage'] as String?;
+
     if (isFlutterInstalled) {
       try {
         await Flutter.test(
@@ -67,6 +75,7 @@ class TestCommand extends Command<int> {
           stderr: _logger.err,
           collectCoverage: collectCoverage,
           minCoverage: minCoverage,
+          excludeFromCoverage: excludeFromCoverage,
           arguments: [
             if (excludeTags != null) ...['-x', excludeTags],
             ..._argResults.rest,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   args: ^2.1.0
+  glob: ^2.0.2
   lcov_parser: ^0.1.2
   mason: ">=0.1.0-dev.9 <0.1.0-dev.10"
   mason_logger: ^0.1.0-dev.6


### PR DESCRIPTION
## Description

Adds a `--exclude-coverage` flag to the test command so users can ignore files (like generated ones, etc) when collecting the coverage.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
