### PR TITLE
Fixed command in create new Flutter app with custom organization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Usage: very_good create <output directory>
 very_good create my_app --desc "My new Flutter app"
 
 # Create a new Flutter app named my_app with a custom org
-very_good create my_app --desc "My new Flutter app" --org "com.custom.org"
+very_good create my_app --desc "My new Flutter app" --org-name "com.custom.org"
 
 # Create a new Flutter package named my_flutter_package
 very_good create my_flutter_package -t flutter_pkg --desc "My new Flutter package"


### PR DESCRIPTION
## Description

I notice that in Readme, commands section, you wrote `--org-name`, but in the following example is written like `--org`. I think that it can be a typing mistake.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X ] 📝 Documentation
- [ ] 🗑️ Chore
