### PR TITLE
fix(373): check if there is a test directory before run flutter test

### DIFF
--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -143,6 +143,13 @@ class Flutter {
           'Running "flutter test" in ${p.dirname(workingDirectory)}...\n',
         );
 
+        if (!Directory(p.join(target.dir.absolute.path, 'test')).existsSync()) {
+          stdout?.call(
+            'No test folder found in ${target.dir.absolute.path}',
+          );
+          return Future.value(ExitCode.success.code);
+        }
+
         if (randomSeed != null) {
           stdout?.call(
             '''Shuffling test order with --test-randomize-ordering-seed=$randomSeed\n''',

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -147,7 +147,7 @@ class Flutter {
           stdout?.call(
             'No test folder found in ${target.dir.absolute.path}',
           );
-          return Future.value(ExitCode.success.code);
+          return ExitCode.success.code;
         }
 
         if (randomSeed != null) {

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -329,14 +329,24 @@ void main() {
         ).ensureDeleted();
       });
 
-      test('exits with code 69 when there is no test directory', () {
+      test('exits with code success when there is no test directory', () {
         final directory = Directory.systemTemp.createTempSync();
         File(p.join(directory.path, 'pubspec.yaml')).writeAsStringSync(pubspec);
 
         expectLater(
-          Flutter.test(cwd: directory.path),
-          completion(equals([69])),
+          Flutter.test(cwd: directory.path, stdout: logger.write),
+          completion(equals([ExitCode.success.code])),
         );
+
+        verify(
+          () => logger.write(
+            any(
+              that: contains(
+                'No test folder found in ${directory.path}',
+              ),
+            ),
+          ),
+        ).called(1);
       });
 
       test('throws when there is no pubspec.yaml (recursive)', () {

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -329,7 +329,7 @@ void main() {
         ).ensureDeleted();
       });
 
-      test('exits with code success when there is no test directory', () {
+      test('exits with code 0 when there is no test directory', () {
         final directory = Directory.systemTemp.createTempSync();
         File(p.join(directory.path, 'pubspec.yaml')).writeAsStringSync(pubspec);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->


## Description

Check if there is a `test` directory before calling the `flutter test`.

Proposal to fix the #373 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
