### PR TITLE
fix: move alert messages to custom method

### DIFF
--- a/lib/src/commands/create/templates/dart_package/dart_package_template.dart
+++ b/lib/src/commands/create/templates/dart_package/dart_package_template.dart
@@ -1,6 +1,7 @@
 import 'package:mason/mason.dart';
 import 'package:universal_io/io.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 /// {@template dart_pkg_template}
 /// A Dart package template.
@@ -24,7 +25,7 @@ class DartPkgTemplate extends Template {
   void _logSummary(Logger logger) {
     logger
       ..info('\n')
-      ..alert('Created a Very Good Dart Package! 🦄')
+      ..created('Created a Very Good Dart Package! 🦄')
       ..info('\n');
   }
 }

--- a/lib/src/commands/create/templates/flutter_package/flutter_package_template.dart
+++ b/lib/src/commands/create/templates/flutter_package/flutter_package_template.dart
@@ -1,6 +1,7 @@
 import 'package:mason/mason.dart';
 import 'package:universal_io/io.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 /// {@template flutter_pkg_template}
 /// A Flutter package template.
@@ -24,7 +25,7 @@ class FlutterPkgTemplate extends Template {
   void _logSummary(Logger logger) {
     logger
       ..info('\n')
-      ..alert('Created a Very Good Flutter Package! 🦄')
+      ..created('Created a Very Good Flutter Package! 🦄')
       ..info('\n');
   }
 }

--- a/lib/src/commands/create/templates/flutter_plugin/flutter_plugin_template.dart
+++ b/lib/src/commands/create/templates/flutter_plugin/flutter_plugin_template.dart
@@ -1,6 +1,7 @@
 import 'package:mason/mason.dart';
 import 'package:universal_io/io.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 /// {@template flutter_plugin_template}
 /// A Flutter plugin template.
@@ -24,7 +25,7 @@ class FlutterPluginTemplate extends Template {
   void _logSummary(Logger logger) {
     logger
       ..info('\n')
-      ..alert('Created a Very Good Flutter Plugin! 🦄')
+      ..created('Created a Very Good Flutter Plugin! 🦄')
       ..info('\n');
   }
 }

--- a/lib/src/commands/create/templates/very_good_core/very_good_core_template.dart
+++ b/lib/src/commands/create/templates/very_good_core/very_good_core_template.dart
@@ -1,6 +1,7 @@
 import 'package:mason/mason.dart';
 import 'package:universal_io/io.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 /// {@template very_good_core_template}
 /// A core Flutter app template.
@@ -24,7 +25,7 @@ class VeryGoodCoreTemplate extends Template {
   void _logSummary(Logger logger) {
     logger
       ..info('\n')
-      ..alert('Created a Very Good App! 🦄')
+      ..created('Created a Very Good App! 🦄')
       ..info('\n')
       ..info(
         lightGray.wrap(

--- a/lib/src/commands/create/templates/very_good_dart_cli/very_good_dart_cli_template.dart
+++ b/lib/src/commands/create/templates/very_good_dart_cli/very_good_dart_cli_template.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:mason_logger/mason_logger.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 /// {@template dart_cli_template}
 /// A Dart CLI application template.
@@ -25,7 +26,7 @@ class VeryGoodDartCLITemplate extends Template {
   void _logSummary(Logger logger) {
     logger
       ..info('\n')
-      ..alert('Created a Very Good Dart CLI application! 🦄')
+      ..created('Created a Very Good Dart CLI application! 🦄')
       ..info('\n');
   }
 }

--- a/lib/src/logger_extension.dart
+++ b/lib/src/logger_extension.dart
@@ -1,0 +1,9 @@
+import 'package:mason_logger/mason_logger.dart';
+
+/// Extension on the Logger class for custom styled logging.
+extension LoggerX on Logger {
+  /// Log a message in the "created" style of the CLI.
+  void created(String message) {
+    info(lightCyan.wrap(styleBold.wrap(message)));
+  }
+}

--- a/test/src/commands/create/create_test.dart
+++ b/test/src/commands/create/create_test.dart
@@ -11,6 +11,7 @@ import 'package:usage/usage_io.dart';
 import 'package:very_good_cli/src/command_runner.dart';
 import 'package:very_good_cli/src/commands/create/create.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
 
 import '../../../helpers/helpers.dart';
 
@@ -219,7 +220,7 @@ void main() {
       verify(
         () => logger.progress('Running "flutter packages get" in .tmp'),
       ).called(1);
-      verify(() => logger.alert('Created a Very Good App! 🦄')).called(1);
+      verify(() => logger.created('Created a Very Good App! 🦄')).called(1);
       verify(
         () => generator.generate(
           any(
@@ -565,7 +566,7 @@ void main() {
           verify(
             () => logger.progress(getPackagesMsg),
           ).called(1);
-          verify(() => logger.alert(expectedLogSummary)).called(1);
+          verify(() => logger.created(expectedLogSummary)).called(1);
           verify(
             () => generator.generate(
               any(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

After talking with @renancaraujo and @felangel we came to the conclusion that we were abusing the alert message, it is meant to indicate something severe or a call to action but we mostly used it for the pretty colors.

Fixing that by moving to a custom message that uses these pretty colors.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
