### PR TITLE
docs: adding docs about --no-pub

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Run "very_good help" to see global options.
 
 #### Tests without pub install
 
-Differently from `flutter test`, `very_good test` will always run your tests without first installing the projects dependencies (i.e. `--no-pub` flag).
+Unlike `flutter test`, `very_good test` will always run your tests without installing the projects dependencies (i.e. `--no-pub` flag).
 
 This is part of the test optimization provided by the cli, since usually the only time where dependencies installation would be required is on a fresh clonned repository, and a developer would normally be running tests multiple times on their local repository, by not running `pub get` we gain a few seconds since no network call to pub is made.
 

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Run "very_good help" to see global options.
 
 Unlike `flutter test`, `very_good test` will always run your tests without installing the projects dependencies (i.e. `--no-pub` flag).
 
-This is part of the test optimization provided by the cli, since usually the only time where dependencies installation would be required is on a fresh clonned repository, and a developer would normally be running tests multiple times on their local repository, by not running `pub get` we gain a few seconds since no network call to pub is made.
+This is an optimization done by the cli because dependency installation is usually run once after cloning the repository. Conversely, running tests locally is usually done many times and it's often unnecessary to re-install dependencies prior to each test run.
 
-If you need to install dependencies before running the tests with `very_good` cli, be sure to run `very_good packages get` first.
+If you need to install dependencies before running the tests with `very_good_cli`, be sure to run `very_good packages get` first.
 
 ### `very_good --help`
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Usage: very_good test [arguments]
 Run "very_good help" to see global options.
 ```
 
+#### Tests without pub install
+
+Differently from `flutter test`, `very_good test` will always run your tests without first installing the projects dependencies (i.e. `--no-pub` flag).
+
+This is part of the test optimization provided by the cli, since usually the only time where dependencies installation would be required is on a fresh clonned repository, and a developer would normally be running tests multiple times on their local repository, by not running `pub get` we gain a few seconds since no network call to pub is made.
+
+If you need to install dependencies before running the tests with `very_good` cli, be sure to run `very_good packages get` first.
+
 ### `very_good --help`
 
 See the complete list of commands and usage information.


### PR DESCRIPTION
## Description

As explained on #504 [here](https://github.com/VeryGoodOpenSource/very_good_cli/issues/504#issuecomment-1273872050), we enforce `--no-pub` by design.

This PR adds a brief section on the README explaining about that.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
