### PR TITLE
feat: Allow force ansi output to enhance log readibility

### DIFF
--- a/lib/src/commands/test/test.dart
+++ b/lib/src/commands/test/test.dart
@@ -23,6 +23,7 @@ typedef FlutterTestCommand = Future<List<int>> Function({
   double? minCoverage,
   String? excludeFromCoverage,
   String? randomSeed,
+  bool? forceAnsi,
   List<String>? arguments,
   void Function(String)? stdout,
   void Function(String)? stderr,
@@ -93,6 +94,13 @@ class TestCommand extends Command<int> {
             'should update the golden files.',
         negatable: false,
       )
+      ..addFlag(
+        'force-ansi',
+        defaultsTo: null,
+        help: 'Whether to force ansi output. If not specified, '
+            'it will maintain the default behavior based on stdout and stderr.',
+        negatable: false,
+      )
       ..addMultiOption(
         'dart-define',
         help: 'Additional key-value pairs that will be available as constants '
@@ -151,6 +159,7 @@ This command should be run from the root of your Flutter project.''',
         : randomOrderingSeed;
     final optimizePerformance = _argResults['optimization'] as bool;
     final updateGoldens = _argResults['update-goldens'] as bool;
+    final forceAnsi = _argResults['force-ansi'] as bool?;
     final dartDefine = _argResults['dart-define'] as List<String>?;
 
     if (isFlutterInstalled) {
@@ -166,6 +175,7 @@ This command should be run from the root of your Flutter project.''',
           minCoverage: minCoverage,
           excludeFromCoverage: excludeFromCoverage,
           randomSeed: randomSeed,
+          forceAnsi: forceAnsi,
           arguments: [
             if (excludeTags != null) ...['-x', excludeTags],
             if (tags != null) ...['-t', tags],

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -414,6 +414,47 @@ void main() {
         directory.delete(recursive: true).ignore();
       });
 
+      test('runs tests (passing) with forced ansi output', () async {
+        final directory = Directory.systemTemp.createTempSync();
+        File(p.join(directory.path, 'pubspec.yaml')).createSync();
+        Directory(p.join(directory.path, 'test')).createSync();
+
+        await expectLater(
+          Flutter.test(
+            cwd: directory.path,
+            stdout: stdoutLogs.add,
+            stderr: stderrLogs.add,
+            testRunner: testRunner(
+              Stream.fromIterable([
+                ...passingJsonOutput.map(TestEvent.fromJson),
+                const ExitTestEvent(exitCode: 0, time: 0),
+              ]),
+            ),
+            logger: logger,
+            forceAnsi: true,
+          ),
+          completion(equals([ExitCode.success.code])),
+        );
+
+        expect(
+          stdoutLogs,
+          equals([
+            'Running "flutter test" in ${p.dirname(directory.path)}...\n',
+            '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+1\x1B[0m: CounterCubit initial state is 0''',
+            '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+2\x1B[0m: CounterCubit emits [1] when increment is called''',
+            '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+3\x1B[0m: CounterCubit emits [-1] when decrement is called''',
+            '''\x1B[2K\r\x1B[90m00:03\x1B[0m \x1B[92m+4\x1B[0m: App renders CounterPage''',
+            '''\x1B[2K\r\x1B[90m00:03\x1B[0m \x1B[92m+5\x1B[0m: CounterPage renders CounterView''',
+            '''\x1B[2K\r\x1B[90m00:03\x1B[0m \x1B[92m+6\x1B[0m: CounterView renders current count''',
+            '''\x1B[2K\r\x1B[90m00:03\x1B[0m \x1B[92m+7\x1B[0m: ...rView calls increment when increment button is tapped''',
+            '''\x1B[2K\r\x1B[90m00:03\x1B[0m \x1B[92m+8\x1B[0m: ...rView calls decrement when decrement button is tapped''',
+            '''\x1B[2K\r\x1B[90m\x1B[90m00:04\x1B[0m\x1B[0m \x1B[92m+8\x1B[0m: \x1B[92mAll tests passed!\x1B[0m\n'''
+          ]),
+        );
+        expect(stderrLogs, isEmpty);
+        directory.delete(recursive: true).ignore();
+      });
+
       test('runs tests (failing)', () async {
         final directory = Directory.systemTemp.createTempSync();
         File(p.join(directory.path, 'pubspec.yaml')).createSync();

--- a/test/src/commands/test/test_test.dart
+++ b/test/src/commands/test/test_test.dart
@@ -28,6 +28,7 @@ const expectedTestUsage = [
       '''    --min-coverage                    Whether to enforce a minimum coverage percentage.\n'''
       '''    --test-randomize-ordering-seed    The seed to randomize the execution order of test cases within test files.\n'''
       '''    --update-goldens                  Whether "matchesGoldenFile()" calls within your test methods should update the golden files.\n'''
+      '''    --force-ansi                      Whether to force ansi output. If not specified, it will maintain the default behavior based on stdout and stderr.\n'''
       '''    --dart-define=<foo=bar>           Additional key-value pairs that will be available as constants from the String.fromEnvironment, bool.fromEnvironment, int.fromEnvironment, and double.fromEnvironment constructors. Multiple defines can be passed by repeating "--dart-define" multiple times.\n'''
       '\n'
       'Run "very_good help" to see global options.'
@@ -47,6 +48,7 @@ abstract class FlutterTestCommand {
     Logger? logger,
     void Function(String)? stdout,
     void Function(String)? stderr,
+    bool? forceAnsi,
   });
 }
 
@@ -92,6 +94,7 @@ void main() {
           logger: any(named: 'logger'),
           stdout: any(named: 'stdout'),
           stderr: any(named: 'stderr'),
+          forceAnsi: any(named: 'forceAnsi'),
         ),
       ).thenAnswer((_) async => [0]);
       when<dynamic>(() => argResults['concurrency']).thenReturn(concurrency);
@@ -473,6 +476,24 @@ void main() {
           logger: logger,
           stdout: logger.write,
           stderr: logger.err,
+        ),
+      ).called(1);
+    });
+
+    test('completes normally --force-ansi', () async {
+      when<dynamic>(() => argResults['force-ansi']).thenReturn(true);
+      final result = await testCommand.run();
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => flutterTest(
+          optimizePerformance: true,
+          arguments: [
+            ...defaultArguments,
+          ],
+          logger: logger,
+          stdout: logger.write,
+          stderr: logger.err,
+          forceAnsi: true,
         ),
       ).called(1);
     });


### PR DESCRIPTION

## Description

The aim of this PR is to allow force ansi output even the output isn't tty. This option is helpful for CI like gitlab CI or other CI tools that support ansi output. This allows more readable log particularly the final report.

Code tested with Gitlab-CI. 

- Without ansi-output
<img width="402" alt="Capture d’écran 2022-10-30 à 00 55 58" src="https://user-images.githubusercontent.com/5896654/198855465-1b79a683-0cb9-4093-b9cc-3651f7f71ab6.png">

- With ansi-output
<img width="336" alt="Capture d’écran 2022-10-30 à 00 57 19" src="https://user-images.githubusercontent.com/5896654/198855466-e69595ce-3b90-4730-9fdf-5d84b0a57071.png">
 


## Type of Change


- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
