### PR TITLE
docs: adding missing arguments on the create docs

### DIFF
--- a/site/docs/overview.md
+++ b/site/docs/overview.md
@@ -63,6 +63,8 @@ Usage: very_good create <project name>
                               (defaults to "true")
     --windows                 The plugin supports the Windows platform.
                               (defaults to "true")
+    --application-id          The bundle identifier on iOS or application id on Android. (defaults to <org-name>.<project-name>)
+    --publishable             Whether the generated project is intended to be published (Does not affect flutter application templates)
 ```
 
 ### `very_good packages get`


### PR DESCRIPTION
## Description

Both the application id and publishable arguments from the create command were missing in the site docs.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
