### PR TITLE
fix(test_optimizer): set dart constraint to v2.18.0

### DIFF
--- a/.github/workflows/test_optimizer.yaml
+++ b/.github/workflows/test_optimizer.yaml
@@ -22,7 +22,7 @@ jobs:
   build_hooks:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 2.19.0
+      dart_sdk: 2.18.0
       working_directory: bricks/test_optimizer/hooks
 
   verify_bundle:
@@ -39,4 +39,4 @@ jobs:
         run: tool/generate_test_optimizer_bundle.sh
 
       - name: Check for unbundled changes
-        run: git diff --exit-code --quiet || { echo "::error::Changes detected on the test_opitimizer brick. Please run tools/generate_test_optimizer_bundle.sh to bundle these changes"; exit 1; }
+        run: git diff --exit-code --quiet || { echo "::error::Changes detected on the test_optimizer brick. Please run tool/generate_test_optimizer_bundle.sh to bundle these changes"; exit 1; }

--- a/.github/workflows/test_optimizer.yaml
+++ b/.github/workflows/test_optimizer.yaml
@@ -22,7 +22,7 @@ jobs:
   build_hooks:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 2.19.0
+      dart_sdk: 2.18.0
       working_directory: bricks/test_optimizer/hooks
 
   verify_bundle:

--- a/.github/workflows/test_optimizer.yaml
+++ b/.github/workflows/test_optimizer.yaml
@@ -22,7 +22,7 @@ jobs:
   build_hooks:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
     with:
-      dart_sdk: 2.18.0
+      dart_sdk: 2.19.0
       working_directory: bricks/test_optimizer/hooks
 
   verify_bundle:

--- a/bricks/test_optimizer/hooks/pubspec.yaml
+++ b/bricks/test_optimizer/hooks/pubspec.yaml
@@ -2,7 +2,7 @@ name: hooks
 publish_to: none
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   mason: ">=0.1.0-dev.41 <0.1.0"

--- a/lib/src/commands/test/templates/test_optimizer_bundle.dart
+++ b/lib/src/commands/test/templates/test_optimizer_bundle.dart
@@ -35,7 +35,7 @@ final testOptimizerBundle = MasonBundle.fromJson(<String, dynamic>{
     {
       "path": "pubspec.yaml",
       "data":
-          "bmFtZTogaG9va3MKcHVibGlzaF90bzogbm9uZQoKZW52aXJvbm1lbnQ6CiAgc2RrOiAiPj0yLjE5LjAgPDMuMC4wIgoKZGVwZW5kZW5jaWVzOgogIG1hc29uOiAiPj0wLjEuMC1kZXYuNDEgPDAuMS4wIgogIHBhdGg6IF4xLjguMQoKZGV2X2RlcGVuZGVuY2llczoKICBtb2NrdGFpbDogXjAuMy4wCiAgdGVzdDogXjEuMjIuMgogIHZlcnlfZ29vZF9hbmFseXNpczogXjQuMC4wCg==",
+          "bmFtZTogaG9va3MKcHVibGlzaF90bzogbm9uZQoKZW52aXJvbm1lbnQ6CiAgc2RrOiAiPj0yLjE4LjAgPDMuMC4wIgoKZGVwZW5kZW5jaWVzOgogIG1hc29uOiAiPj0wLjEuMC1kZXYuNDEgPDAuMS4wIgogIHBhdGg6IF4xLjguMQoKZGV2X2RlcGVuZGVuY2llczoKICBtb2NrdGFpbDogXjAuMy4wCiAgdGVzdDogXjEuMjIuMgogIHZlcnlfZ29vZF9hbmFseXNpczogXjQuMC4wCg==",
       "type": "text"
     },
     {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The `test_optimizer` brick hooks have a higher dart constraint than the CLI itself, meaning our users can no longer run tests using the CLI when they are on 2.18.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
