### PR TITLE
feat(spdx_license): include tryParse

### DIFF
--- a/bricks/spdx_license/__brick__/spdx_license.gen.dart
+++ b/bricks/spdx_license/__brick__/spdx_license.gen.dart
@@ -23,10 +23,28 @@ enum SpdxLicense {
 
   /// Parses a [String] into a [SpdxLicense].
   ///
-  /// If the [value] is not a valid [SpdxLicense], [SpdxLicense.$unknown] is
-  /// returned instead.
-  factory SpdxLicense.parse(String value) =>
-      _valueMap[value] ?? SpdxLicense.$unknown;
+  /// If the [source] is not a valid [SpdxLicense], a [FormatException] is
+  /// thrown.
+  factory SpdxLicense.parse(String source) {
+    final result = _valueMap[source];
+    if (result == null) {
+      throw FormatException('Failed to parse $source as SpdxLicense.');
+    }
+
+    return result;
+  }
+
+  /// Parse [source] into a possible [SpdxLicense].
+  ///
+  /// Like [SpdxLicense.parse] except that it returns `null` where a similar
+  /// call to [SpdxLicense.parse] would throw a [FormatException].
+  static SpdxLicense? tryParse(String source) {
+    try {
+      return SpdxLicense.parse(source);
+    } on FormatException {
+      return null;
+    }
+  }
 
   static final Map<String, SpdxLicense> _valueMap = SpdxLicense.values
       .asNameMap()


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Adds a `tryParse` method to validate future CLI user inputs when white/black listing certain licenses. `unknown` will be a valid license type but erroneous input (for example, `MIP` instead of `MIT`) should throw an exception for a better user experience.

Changes:
- Modified `parse` to throw a FormatException when failed to parse (similar to int.parse)
- Included `tryParse` to return null if can't be parsed (similar to int.tryParse)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
