### PR TITLE
fix: ignore empty allowed or forbidden

### DIFF
--- a/lib/src/commands/packages/commands/check/commands/licenses.dart
+++ b/lib/src/commands/packages/commands/check/commands/licenses.dart
@@ -103,6 +103,9 @@ class PackagesCheckLicensesCommand extends Command<int> {
     final forbiddenLicenses = _argResults['forbidden'] as List<String>;
     final skippedPackages = _argResults['skip-packages'] as List<String>;
 
+    allowedLicenses.removeWhere((license) => license.trim().isEmpty);
+    forbiddenLicenses.removeWhere((license) => license.trim().isEmpty);
+
     if (allowedLicenses.isNotEmpty && forbiddenLicenses.isNotEmpty) {
       usageException(
         '''Cannot specify both ${styleItalic.wrap('allowed')} and ${styleItalic.wrap('forbidden')} options.''',


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Ignores empty allow or forbidden.

**After**
```sh
very_good packages check licenses --allowed="" --forbidden="" 
# Reports, equivalent to `very_good packages check licenses`

very_good packages check licenses --allowed="MIT" --forbidden="" 
# Reports with allowed, equivalent to `very_good packages check licenses --allowed="MIT"`

very_good packages check licenses --allowed="" --forbidden="MIT" 
# Reports with forbidden, equivalent to `very_good packages check licenses --forbidden="MIT"`
```

**Before**
```sh
very_good packages check licenses --allowed="" --forbidden="" 
# Throws usage exception, cannot specify both allowed and forbidden options.

very_good packages check licenses --allowed="MIT" --forbidden="" 
# Throws usage exception, cannot specify both allowed and forbidden options.

very_good packages check licenses --allowed="" --forbidden="MIT" 
# Throws usage exception, cannot specify both allowed and forbidden options.
```



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
