### PR TITLE
fix: update generate_bundles.sh to only format bundles

### DIFF
--- a/tool/generate_bundles.sh
+++ b/tool/generate_bundles.sh
@@ -18,4 +18,4 @@ do
     mason bundle --source hosted $brick --type dart --output-dir "lib/src/commands/create/templates/$brick/"
 done
 
-dart format .
+dart format lib/src/commands/create/templates


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Updates the "generate_bundles.sh" script to only format bundles. This avoids the "bump_templates.yaml" bundle to terminate unnecessarily.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
