### PR TITLE
Use relative path instead of absolute when running `packages get`

### DIFF
--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -84,10 +84,14 @@ class Flutter {
     bool recursive = false,
     Set<String> ignore = const {},
   }) async {
+    final initialCwd = cwd;
+
     await _runCommand(
       cmd: (cwd) async {
+        final diff = p.relative(cwd, from: initialCwd);
+
         final installProgress = logger.progress(
-          'Running "flutter packages get" in $cwd',
+          'Running "flutter packages get" in $diff',
         );
 
         try {

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -88,10 +88,11 @@ class Flutter {
 
     await _runCommand(
       cmd: (cwd) async {
-        final diff = p.relative(cwd, from: initialCwd);
+        final relativePath = p.relative(cwd, from: initialCwd);
 
         final installProgress = logger.progress(
-          'Running "flutter packages get" in .${p.context.separator}$diff',
+          'Running "flutter packages get" in '
+          '.${p.context.separator}$relativePath',
         );
 
         try {

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -91,7 +91,7 @@ class Flutter {
         final diff = p.relative(cwd, from: initialCwd);
 
         final installProgress = logger.progress(
-          'Running "flutter packages get" in $diff',
+          'Running "flutter packages get" in .${p.context.separator}$diff',
         );
 
         try {

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -216,7 +216,7 @@ void main() {
                 any(
                   that: contains(
                     'Running "flutter packages get" in '
-                    '$nestedRelativePath',
+                    '.${p.context.separator}$nestedRelativePath',
                   ),
                 ),
               );
@@ -232,7 +232,7 @@ void main() {
                 any(
                   that: contains(
                     'Running "flutter packages get" in '
-                    '$ignoredRelativePath',
+                    './$ignoredRelativePath',
                   ),
                 ),
               );

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -209,23 +209,30 @@ void main() {
             ),
             runProcess: process.run,
           ).whenComplete(() {
+            final nestedRelativePath =
+                p.relative(nestedDirectory.path, from: tempDirectory.path);
             verify(() {
               logger.progress(
                 any(
                   that: contains(
                     'Running "flutter packages get" in '
-                    '${nestedDirectory.path}',
+                    '$nestedRelativePath',
                   ),
                 ),
               );
             }).called(1);
 
             verifyNever(() {
+              final ignoredRelativePath = p.relative(
+                ignoredDirectory.path,
+                from: tempDirectory.path,
+              );
+
               logger.progress(
                 any(
                   that: contains(
                     'Running "flutter packages get" in '
-                    '${ignoredDirectory.path}',
+                    '$ignoredRelativePath',
                   ),
                 ),
               );

--- a/test/src/commands/packages/commands/get_test.dart
+++ b/test/src/commands/packages/commands/get_test.dart
@@ -347,7 +347,8 @@ void main() {
           logger.progress(
             any(
               that: contains(
-                'Running "flutter packages get" in ${directoryA.path}',
+                'Running "flutter packages get" in '
+                '${path.relative(directoryA.path, from: tempDirectory.path)}',
               ),
             ),
           );
@@ -356,7 +357,8 @@ void main() {
           logger.progress(
             any(
               that: contains(
-                'Running "flutter packages get" in ${directoryB.path}',
+                'Running "flutter packages get" in '
+                '${path.relative(directoryB.path, from: tempDirectory.path)}',
               ),
             ),
           );

--- a/test/src/commands/packages/commands/get_test.dart
+++ b/test/src/commands/packages/commands/get_test.dart
@@ -348,6 +348,7 @@ void main() {
             any(
               that: contains(
                 'Running "flutter packages get" in '
+                '.${path.context.separator}'
                 '${path.relative(directoryA.path, from: tempDirectory.path)}',
               ),
             ),
@@ -358,6 +359,7 @@ void main() {
             any(
               that: contains(
                 'Running "flutter packages get" in '
+                '.${path.context.separator}'
                 '${path.relative(directoryB.path, from: tempDirectory.path)}',
               ),
             ),


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
The change introduced in this PR is to clean up the console when the cwd is printed to console. Specifically when running `very_good packages get`.
There are times when the full path of the cwd is too long causing the logger to behave unexpectedly.

![image](https://github.com/VeryGoodOpenSource/very_good_cli/assets/39742020/60141b7d-9c6d-4273-af6f-d672912680e4)

A solution to the problem is to shorten the path printed to console. Instead of printing the absolute path, the relative path is used.

![image](https://github.com/VeryGoodOpenSource/very_good_cli/assets/39742020/c96ebd7b-99a4-465d-a537-7406ddd7e8d1)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
