### PR TITLE
refactor: Use relative path instead of absolute when running `test`

### DIFF
--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -168,9 +168,8 @@ class Flutter {
         final target = DirectoryGeneratorTarget(Directory(p.normalize(cwd)));
         final workingDirectory = target.dir.absolute.path;
         final relativePath = p.relative(workingDirectory, from: initialCwd);
-        final relativePathPrefix = '.${p.context.separator}';
         final path =
-            relativePath == '.' ? '.' : '$relativePathPrefix$relativePath';
+            relativePath == '.' ? '.' : '.${p.context.separator}$relativePath';
 
         stdout?.call(
           'Running "flutter test" in $path ...\n',

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -168,14 +168,17 @@ class Flutter {
         final target = DirectoryGeneratorTarget(Directory(p.normalize(cwd)));
         final workingDirectory = target.dir.absolute.path;
         final relativePath = p.relative(workingDirectory, from: initialCwd);
+        final relativePathPrefix = '.${p.context.separator}';
+        final path =
+            relativePath == '.' ? '.' : '$relativePathPrefix$relativePath';
 
         stdout?.call(
-          'Running "flutter test" in .${p.context.separator}$relativePath...\n',
+          'Running "flutter test" in $path ...\n',
         );
 
         if (!Directory(p.join(target.dir.absolute.path, 'test')).existsSync()) {
           stdout?.call(
-            'No test folder found in .${p.context.separator}$relativePath\n',
+            'No test folder found in $path\n',
           );
           return ExitCode.success.code;
         }

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -153,6 +153,8 @@ class Flutter {
     FlutterTestRunner testRunner = flutterTest,
     GeneratorBuilder buildGenerator = MasonGenerator.fromBundle,
   }) async {
+    final initialCwd = cwd;
+
     return _runCommand<int>(
       cmd: (cwd) async {
         final lcovPath = p.join(cwd, 'coverage', 'lcov.info');
@@ -165,14 +167,15 @@ class Flutter {
         void noop(String? _) {}
         final target = DirectoryGeneratorTarget(Directory(p.normalize(cwd)));
         final workingDirectory = target.dir.absolute.path;
+        final diff = p.relative(workingDirectory, from: initialCwd);
 
         stdout?.call(
-          'Running "flutter test" in ${p.dirname(workingDirectory)}...\n',
+          'Running "flutter test" in .${p.context.separator}$diff...\n',
         );
 
         if (!Directory(p.join(target.dir.absolute.path, 'test')).existsSync()) {
           stdout?.call(
-            'No test folder found in ${target.dir.absolute.path}\n',
+            'No test folder found in .${p.context.separator}$diff\n',
           );
           return ExitCode.success.code;
         }

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -167,15 +167,15 @@ class Flutter {
         void noop(String? _) {}
         final target = DirectoryGeneratorTarget(Directory(p.normalize(cwd)));
         final workingDirectory = target.dir.absolute.path;
-        final diff = p.relative(workingDirectory, from: initialCwd);
+        final relativePath = p.relative(workingDirectory, from: initialCwd);
 
         stdout?.call(
-          'Running "flutter test" in .${p.context.separator}$diff...\n',
+          'Running "flutter test" in .${p.context.separator}$relativePath...\n',
         );
 
         if (!Directory(p.join(target.dir.absolute.path, 'test')).existsSync()) {
           stdout?.call(
-            'No test folder found in .${p.context.separator}$diff\n',
+            'No test folder found in .${p.context.separator}$relativePath\n',
           );
           return ExitCode.success.code;
         }

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -394,8 +394,8 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
-            'No test folder found in .${p.context.separator}.\n',
+            'Running "flutter test" in . ...\n',
+            'No test folder found in .\n',
           ]),
         );
       });
@@ -431,7 +431,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             '\x1B[2K\r00:00 ...',
             contains('All tests passed!'),
           ]),
@@ -462,7 +462,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             '\x1B[2K\r00:02 +1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:02 +2: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:02 +3: CounterCubit emits [-1] when decrement is called''',
@@ -504,7 +504,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+1\x1B[0m: CounterCubit initial state is 0''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+2\x1B[0m: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+3\x1B[0m: CounterCubit emits [-1] when decrement is called''',
@@ -544,7 +544,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             '\x1B[2K\r00:11 -1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:11 +1 -1: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:11 +2 -1: CounterCubit emits [-1] when decrement is called''',
@@ -599,7 +599,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             '\x1B[2K\rSkip: currently failing (see issue 1234)\n',
             '\x1B[2K\r(suite) ${tempDirectory.path}/test/counter/view/other_test.dart (SKIPPED)\n',
             '\x1B[2K\r00:00 ~1: (suite)',
@@ -846,7 +846,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -882,7 +882,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             'Shuffling test order with --test-randomize-ordering-seed=$seed\n',
             contains('All tests passed!'),
           ]),
@@ -928,7 +928,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -969,7 +969,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1016,7 +1016,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1061,7 +1061,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1118,14 +1118,15 @@ void main() {
             tempNestedDirectory.path,
             from: tempDirectory.path,
           );
+          final relativePathPrefix = '.${p.context.separator}';
 
           expect(
             stdoutLogs,
             unorderedEquals([
               'Running "flutter test" in '
-                  '.${p.context.separator}$nestedRelativePath...\n',
+                  '$relativePathPrefix$nestedRelativePath ...\n',
               contains('All tests passed!'),
-              'Running "flutter test" in .${p.context.separator}....\n',
+              'Running "flutter test" in . ...\n',
               contains('All tests passed!'),
             ]),
           );
@@ -1188,15 +1189,16 @@ void main() {
             tempNestedDirectory.path,
             from: tempDirectory.path,
           );
+          final relativePathPrefix = '.${p.context.separator}';
 
           expect(
             stdoutLogs,
             unorderedEquals([
               'Running "flutter test" in '
-                  '.${p.context.separator}....\n',
+                  '. ...\n',
               contains('All tests passed!'),
               'Running "flutter test" in '
-                  '.${p.context.separator}$nestedRelativePath...\n',
+                  '$relativePathPrefix$nestedRelativePath ...\n',
               contains('All tests passed!'),
             ]),
           );
@@ -1252,7 +1254,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}....\n',
+            'Running "flutter test" in . ...\n',
             contains('All tests passed!'),
           ]),
         );

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -394,8 +394,8 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
-            'No test folder found in ${tempDirectory.absolute.path}\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
+            'No test folder found in .${p.context.separator}\n',
           ]),
         );
       });
@@ -431,7 +431,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             '\x1B[2K\r00:00 ...',
             contains('All tests passed!'),
           ]),
@@ -462,7 +462,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             '\x1B[2K\r00:02 +1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:02 +2: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:02 +3: CounterCubit emits [-1] when decrement is called''',
@@ -504,7 +504,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+1\x1B[0m: CounterCubit initial state is 0''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+2\x1B[0m: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+3\x1B[0m: CounterCubit emits [-1] when decrement is called''',
@@ -544,7 +544,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             '\x1B[2K\r00:11 -1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:11 +1 -1: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:11 +2 -1: CounterCubit emits [-1] when decrement is called''',
@@ -599,7 +599,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             '\x1B[2K\rSkip: currently failing (see issue 1234)\n',
             '\x1B[2K\r(suite) ${tempDirectory.path}/test/counter/view/other_test.dart (SKIPPED)\n',
             '\x1B[2K\r00:00 ~1: (suite)',
@@ -846,7 +846,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -882,7 +882,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             'Shuffling test order with --test-randomize-ordering-seed=$seed\n',
             contains('All tests passed!'),
           ]),
@@ -928,7 +928,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -969,7 +969,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1016,7 +1016,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1061,7 +1061,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1114,13 +1114,18 @@ void main() {
             completion(equals([ExitCode.success.code, ExitCode.success.code])),
           );
 
+          final nestedRelativePath = p.relative(
+            tempNestedDirectory.path,
+            from: tempDirectory.path,
+          );
+
           expect(
             stdoutLogs,
             unorderedEquals([
               'Running "flutter test" in '
-                  '${p.dirname(tempNestedDirectory.path)}...\n',
+                  '.${p.context.separator}$nestedRelativePath...\n',
               contains('All tests passed!'),
-              'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+              'Running "flutter test" in .${p.context.separator}...\n',
               contains('All tests passed!'),
             ]),
           );
@@ -1179,14 +1184,19 @@ void main() {
             ),
           );
 
+          final nestedRelativePath = p.relative(
+            tempNestedDirectory.path,
+            from: tempDirectory.path,
+          );
+
           expect(
             stdoutLogs,
             unorderedEquals([
               'Running "flutter test" in '
-                  '${p.dirname(tempDirectory.path)}...\n',
+                  '.${p.context.separator}...\n',
               contains('All tests passed!'),
               'Running "flutter test" in '
-                  '${p.dirname(tempNestedDirectory.path)}...\n',
+                  '.${p.context.separator}$nestedRelativePath...\n',
               contains('All tests passed!'),
             ]),
           );
@@ -1242,7 +1252,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in ${p.dirname(tempDirectory.path)}...\n',
+            'Running "flutter test" in .${p.context.separator}...\n',
             contains('All tests passed!'),
           ]),
         );

--- a/test/src/cli/flutter_cli_test.dart
+++ b/test/src/cli/flutter_cli_test.dart
@@ -394,8 +394,8 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
-            'No test folder found in .${p.context.separator}\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
+            'No test folder found in .${p.context.separator}.\n',
           ]),
         );
       });
@@ -431,7 +431,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             '\x1B[2K\r00:00 ...',
             contains('All tests passed!'),
           ]),
@@ -462,7 +462,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             '\x1B[2K\r00:02 +1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:02 +2: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:02 +3: CounterCubit emits [-1] when decrement is called''',
@@ -504,7 +504,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+1\x1B[0m: CounterCubit initial state is 0''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+2\x1B[0m: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r\x1B[90m00:02\x1B[0m \x1B[92m+3\x1B[0m: CounterCubit emits [-1] when decrement is called''',
@@ -544,7 +544,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             '\x1B[2K\r00:11 -1: CounterCubit initial state is 0',
             '''\x1B[2K\r00:11 +1 -1: CounterCubit emits [1] when increment is called''',
             '''\x1B[2K\r00:11 +2 -1: CounterCubit emits [-1] when decrement is called''',
@@ -599,7 +599,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             '\x1B[2K\rSkip: currently failing (see issue 1234)\n',
             '\x1B[2K\r(suite) ${tempDirectory.path}/test/counter/view/other_test.dart (SKIPPED)\n',
             '\x1B[2K\r00:00 ~1: (suite)',
@@ -846,7 +846,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );
@@ -882,7 +882,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             'Shuffling test order with --test-randomize-ordering-seed=$seed\n',
             contains('All tests passed!'),
           ]),
@@ -928,7 +928,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );
@@ -969,7 +969,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1016,7 +1016,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1061,7 +1061,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );
@@ -1125,7 +1125,7 @@ void main() {
               'Running "flutter test" in '
                   '.${p.context.separator}$nestedRelativePath...\n',
               contains('All tests passed!'),
-              'Running "flutter test" in .${p.context.separator}...\n',
+              'Running "flutter test" in .${p.context.separator}....\n',
               contains('All tests passed!'),
             ]),
           );
@@ -1193,7 +1193,7 @@ void main() {
             stdoutLogs,
             unorderedEquals([
               'Running "flutter test" in '
-                  '.${p.context.separator}...\n',
+                  '.${p.context.separator}....\n',
               contains('All tests passed!'),
               'Running "flutter test" in '
                   '.${p.context.separator}$nestedRelativePath...\n',
@@ -1252,7 +1252,7 @@ void main() {
         expect(
           stdoutLogs,
           equals([
-            'Running "flutter test" in .${p.context.separator}...\n',
+            'Running "flutter test" in .${p.context.separator}....\n',
             contains('All tests passed!'),
           ]),
         );


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

Fixes: #754

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
The change introduced in this PR is to clean up the console when the cwd is printed. Specifically when running `very_good test`.
Sometimes the full path of the cwd is too long and would be cut off. If running recursively, this can leave the developer confused as to which directory was tested.

![image](https://github.com/VeryGoodOpenSource/very_good_cli/assets/39742020/a6413b28-7d7f-4eac-8b35-cb38137e7e62)

A solution to the problem is to shorten the path printed to console. Instead of printing the absolute path, the relative path is used.

![image](https://github.com/VeryGoodOpenSource/very_good_cli/assets/39742020/09250cd0-ec9c-4d55-936d-be157d23cff2)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
