### PR TITLE
feat: support 'direct-overridden' dependency type when checking licenses

### DIFF
--- a/e2e/pubspec.yaml
+++ b/e2e/pubspec.yaml
@@ -16,11 +16,3 @@ dev_dependencies:
   very_good_analysis: ^5.1.0
   very_good_cli:
     path: ../
-
-dependency_overrides:
-  pubspec_lock:
-    # Override to support "direct overridden" dependency parsing, remove
-    # once the issue is fixed: https://github.com/alexei-sintotski/pubspec_lock/issues/33
-    git:
-      url: https://github.com/alestiago/pubspec_lock
-      ref: 927ee77351aad84cda381cb5b9606265cf1fe52d

--- a/e2e/pubspec.yaml
+++ b/e2e/pubspec.yaml
@@ -16,3 +16,11 @@ dev_dependencies:
   very_good_analysis: ^5.1.0
   very_good_cli:
     path: ../
+
+dependency_overrides:
+  pubspec_lock:
+    # Override to support "direct overridden" dependency parsing, remove
+    # once the issue is fixed: https://github.com/alexei-sintotski/pubspec_lock/issues/33
+    git:
+      url: https://github.com/alestiago/pubspec_lock
+      ref: 927ee77351aad84cda381cb5b9606265cf1fe52d

--- a/lib/src/commands/packages/commands/check/commands/licenses.dart
+++ b/lib/src/commands/packages/commands/check/commands/licenses.dart
@@ -86,6 +86,7 @@ class PackagesCheckLicensesCommand extends Command<int> {
         allowed: [
           'direct-main',
           'direct-dev',
+          'direct-overridden',
           'transitive',
         ],
         allowedHelp: {
@@ -194,7 +195,9 @@ class PackagesCheckLicensesCommand extends Command<int> {
           (dependencyTypes.contains('direct-dev') &&
               dependencyType == DependencyType.development) ||
           (dependencyTypes.contains('transitive') &&
-              dependencyType == DependencyType.transitive);
+              dependencyType == DependencyType.transitive) ||
+          (dependencyTypes.contains('direct-overridden') &&
+              dependencyType == DependencyType.overridden);
     });
 
     if (filteredDependencies.isEmpty) {

--- a/lib/src/pubspec_lock/pubspec_lock.dart
+++ b/lib/src/pubspec_lock/pubspec_lock.dart
@@ -1,0 +1,186 @@
+/// A simple parser for pubspec.lock files.
+///
+/// This is used by the `packages check license` command to check the type and
+/// source of the dependencies to analyze. Hence it is not a complete parser,
+/// it only parses the information that is needed for the
+/// `packages check license` command.
+library pubspec_lock;
+
+import 'dart:collection';
+
+import 'package:equatable/equatable.dart';
+import 'package:yaml/yaml.dart';
+
+/// {@template PubspecLockParseException}
+/// Thrown when a [PubspecLock] fails to parse.
+/// {@endtemplate}
+class PubspecLockParseException implements Exception {
+  /// {@macro PubspecLockParseException}
+  const PubspecLockParseException();
+}
+
+/// {@template PubspecLock}
+/// A representation of a pubspec.lock file.
+/// {@endtemplate}
+class PubspecLock {
+  const PubspecLock._({
+    required this.packages,
+  });
+
+  /// Parses a [PubspecLock] from a string.
+  ///
+  /// If no packages are found, an empty [PubspecLock] is returned. Those
+  /// packages entries that cannot be parsed are ignored.
+  ///
+  /// It throws a [PubspecLockParseException] if the string cannot be parsed
+  /// as a [YamlMap].
+  factory PubspecLock.fromString(String content) {
+    late final YamlMap yaml;
+    try {
+      yaml = loadYaml(content) as YamlMap;
+    } catch (_) {
+      throw const PubspecLockParseException();
+    }
+
+    if (!yaml.containsKey('packages')) {
+      return PubspecLock.empty;
+    }
+
+    final packages = yaml['packages'] as YamlMap;
+
+    final parsedPackages = <PubspecLockPackage>[];
+    for (final entry in packages.entries) {
+      try {
+        final package = PubspecLockPackage.fromYamlMap(
+          name: entry.key as String,
+          data: entry.value as YamlMap,
+        );
+        parsedPackages.add(package);
+      } catch (_) {
+        // Ignore those packages that for some reason cannot be parsed.
+      }
+    }
+
+    return PubspecLock._(
+      packages: UnmodifiableListView(parsedPackages),
+    );
+  }
+
+  /// An empty [PubspecLock].
+  static PubspecLock empty = PubspecLock._(
+    packages: UnmodifiableListView([]),
+  );
+
+  /// All the dependencies in the pubspec.lock file.
+  final UnmodifiableListView<PubspecLockPackage> packages;
+}
+
+/// {@template PubspecLockDependency}
+/// A representation of a dependency in a pubspec.lock file.
+/// {@endtemplate}
+class PubspecLockPackage extends Equatable {
+  /// {@macro PubspecLockDependency}
+  const PubspecLockPackage({
+    required this.name,
+    required this.type,
+    required this.isPubHosted,
+  });
+
+  /// Parses a [PubspecLockPackage] from a [YamlMap].
+  factory PubspecLockPackage.fromYamlMap({
+    required String name,
+    required YamlMap data,
+  }) {
+    final dependency = data['dependency'] as String;
+    final dependencyType = PubspecLockPackageDependencyType.parse(dependency);
+
+    final source = data['source'] as String;
+    late final bool isPubHosted;
+    if (source == 'hosted') {
+      final description = data['description'] as YamlMap;
+      final url = description['url'] as String;
+      isPubHosted = url == 'https://pub.dev';
+    } else {
+      isPubHosted = false;
+    }
+
+    return PubspecLockPackage(
+      name: name,
+      type: dependencyType,
+      isPubHosted: isPubHosted,
+    );
+  }
+
+  /// The name of the dependency.
+  final String name;
+
+  /// {@macro PubspecLockDependencyType}
+  final PubspecLockPackageDependencyType type;
+
+  /// Whether the dependency is hosted on pub.dev or not.
+  final bool isPubHosted;
+
+  @override
+  List<Object?> get props => [type, isPubHosted];
+}
+
+/// {@template PubspecLockDependencyType}
+/// The type of a [PubspecLockPackage].
+/// {@endtemplate}
+enum PubspecLockPackageDependencyType {
+  /// Another package that your package needs to work.
+  ///
+  /// See also:
+  ///
+  /// * [Dart's dependency documentation](https://dart.dev/tools/pub/dependencies)
+  directMain._('direct main'),
+
+  /// Another package that your package needs during development.
+  ///
+  /// See also:
+  ///
+  /// * [Dart's developer dependency documentation](https://dart.dev/tools/pub/dependencies#dev-dependencies)
+  directDev._('direct dev'),
+
+  /// A dependency that your package indirectly uses because one of its
+  /// dependencies requires it.
+  ///
+  /// See also:
+  ///
+  /// * [Dart's transitive dependency documentation](https://dart.dev/tools/pub/glossary#transitive-)
+  transitive._('transitive'),
+
+  ///  A dependency that your package overrides that is not already a
+  /// `direct main` or `direct dev` dependency.
+  ///
+  /// See also:
+  ///
+  /// * [Dart's dependency override documentation](https://dart.dev/tools/pub/dependencies#dependency-overrides)
+  directOverridden._('direct overridden');
+
+  const PubspecLockPackageDependencyType._(this.value);
+
+  /// Parses a [PubspecLockPackageDependencyType] from a string.
+  ///
+  /// Throws an [ArgumentError] if the string is not a valid dependency type.
+  factory PubspecLockPackageDependencyType.parse(String value) {
+    if (_valueMap.containsKey(value)) {
+      return _valueMap[value]!;
+    }
+
+    throw ArgumentError.value(
+      value,
+      'value',
+      'Invalid PubspecLockPackageDependencyType value.',
+    );
+  }
+
+  static Map<String, PubspecLockPackageDependencyType> _valueMap = {
+    for (final type in PubspecLockPackageDependencyType.values)
+      type.value: type,
+  };
+
+  /// The string representation of the [PubspecLockPackageDependencyType]
+  /// as it appears in a pubspec.lock file.
+  final String value;
+}

--- a/lib/src/pubspec_lock/pubspec_lock.dart
+++ b/lib/src/pubspec_lock/pubspec_lock.dart
@@ -1,7 +1,7 @@
 /// A simple parser for pubspec.lock files.
 ///
 /// This is used by the `packages check license` command to check the type and
-/// source of the dependencies to analyze. Hence it is not a complete parser,
+/// source of the dependencies to analyze. Hence, it is not a complete parser,
 /// it only parses the information that is needed for the
 /// `packages check license` command.
 library pubspec_lock;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,5 +37,13 @@ dev_dependencies:
   test: ^1.24.3
   very_good_analysis: ^5.1.0
 
+dependency_overrides:
+  pubspec_lock:
+    # Override to support "direct overridden" dependency parsing, remove
+    # once the issue is fixed: https://github.com/alexei-sintotski/pubspec_lock/issues/33
+    git:
+      url: https://github.com/PieterAelse/pubspec_lock
+      ref: 93ecf65e537f6202dc28c694143bc6a176d603ef
+
 executables:
   very_good:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   args: ^2.1.0
   cli_completion: ^0.4.0
   collection: ^1.17.1
+  equatable: ^2.0.5
   glob: ^2.0.2
   lcov_parser: ^0.1.2
   mason: 0.1.0-dev.51
@@ -23,11 +24,11 @@ dependencies:
   pana: 0.21.45 # Very Good CLI is using private PANA's license detector that might break in a minor version update.
   path: ^1.8.0
   pub_updater: ">=0.3.1 <0.5.0"
-  pubspec_lock: ^3.0.2
   pubspec_parse: ^1.2.0
   stack_trace: ^1.10.0
   universal_io: ^2.0.4
   very_good_test_runner: ^0.1.2
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.6
@@ -36,14 +37,6 @@ dev_dependencies:
   mocktail: ^1.0.0
   test: ^1.24.3
   very_good_analysis: ^5.1.0
-
-dependency_overrides:
-  pubspec_lock:
-    # Override to support "direct overridden" dependency parsing, remove
-    # once the issue is fixed: https://github.com/alexei-sintotski/pubspec_lock/issues/33
-    git:
-      url: https://github.com/alestiago/pubspec_lock
-      ref: 927ee77351aad84cda381cb5b9606265cf1fe52d
 
 executables:
   very_good:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,8 +42,8 @@ dependency_overrides:
     # Override to support "direct overridden" dependency parsing, remove
     # once the issue is fixed: https://github.com/alexei-sintotski/pubspec_lock/issues/33
     git:
-      url: https://github.com/PieterAelse/pubspec_lock
-      ref: 93ecf65e537f6202dc28c694143bc6a176d603ef
+      url: https://github.com/alestiago/pubspec_lock
+      ref: 927ee77351aad84cda381cb5b9606265cf1fe52d
 
 executables:
   very_good:

--- a/test/src/commands/packages/commands/check/commands/licenses_test.dart
+++ b/test/src/commands/packages/commands/check/commands/licenses_test.dart
@@ -1643,17 +1643,3 @@ sdks:
   dart: ">=3.1.0 <4.0.0"
 
 ''';
-
-const _validDependencyOverridenPubspecLockContent = '''
-packages:
-  path:
-    dependency: "direct overridden"
-    description:
-      name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.9.0"
-sdks:
-  dart: ">=3.1.0 <4.0.0"
-''';

--- a/test/src/commands/packages/commands/check/commands/licenses_test.dart
+++ b/test/src/commands/packages/commands/check/commands/licenses_test.dart
@@ -29,7 +29,7 @@ class _MockPackage extends Mock implements package_config.Package {}
 
 const _expectedPackagesCheckLicensesUsage = [
   // ignore: no_adjacent_strings_in_list
-  "Check packages' licenses in a Dart or Flutter project.\n"
+  '''Check packages' licenses in a Dart or Flutter project.\n'''
       '\n'
       'Usage: very_good packages check licenses [arguments]\n'
       '-h, --help                           Print this usage information.\n'
@@ -38,6 +38,7 @@ const _expectedPackagesCheckLicensesUsage = [
       '\n'
       '''          [direct-dev]               Check for direct dev dependencies.\n'''
       '''          [direct-main] (default)    Check for direct main dependencies.\n'''
+      '''          [direct-overridden]        Check for direct overridden dependencies.\n'''
       '''          [transitive]               Check for transitive dependencies.\n'''
       '\n'
       '''    --allowed                        Only allow the use of certain licenses.\n'''
@@ -1601,6 +1602,7 @@ void main() {
 /// - one hosted direct dependency
 /// - one hosted direct dev dependency
 /// - one hosted transitive dependency
+/// - one hosted overridden dependency
 const _validPubspecLockContent = '''
 packages:
   very_good_test_runner:

--- a/test/src/commands/packages/commands/check/commands/licenses_test.dart
+++ b/test/src/commands/packages/commands/check/commands/licenses_test.dart
@@ -1563,6 +1563,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  path:
+    dependency: "direct overridden"
+    description:
+      name: path
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
 sdks:
   dart: ">=3.1.0 <4.0.0"
 
@@ -1634,4 +1642,18 @@ const _emptyPubspecLockContent = '''
 sdks:
   dart: ">=3.1.0 <4.0.0"
 
+''';
+
+const _validDependencyOverridenPubspecLockContent = '''
+packages:
+  path:
+    dependency: "direct overridden"
+    description:
+      name: path
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
+sdks:
+  dart: ">=3.1.0 <4.0.0"
 ''';

--- a/test/src/pubspec_lock/pubspec_lock_test.dart
+++ b/test/src/pubspec_lock/pubspec_lock_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 import 'package:very_good_cli/src/pubspec_lock/pubspec_lock.dart';
 
 void main() {
-  group('PubspecLock', () {
+  group('$PubspecLock', () {
     group('fromString', () {
       test('parses correctly', () {
         final pubspecLock = PubspecLock.fromString(_pubspecLockContent);
@@ -62,7 +62,7 @@ void main() {
     });
   });
 
-  group('PubspecLockPackage', () {
+  group('$PubspecLockPackage', () {
     test('can be instantiated', () {
       expect(
         PubspecLockPackage(

--- a/test/src/pubspec_lock/pubspec_lock_test.dart
+++ b/test/src/pubspec_lock/pubspec_lock_test.dart
@@ -1,0 +1,157 @@
+// ignore_for_file: prefer_const_constructors
+
+import 'package:test/test.dart';
+import 'package:very_good_cli/src/pubspec_lock/pubspec_lock.dart';
+
+void main() {
+  group('PubspecLock', () {
+    group('fromString', () {
+      test('parses correctly', () {
+        final pubspecLock = PubspecLock.fromString(_pubspecLockContent);
+
+        expect(
+          pubspecLock.packages,
+          equals(
+            const [
+              PubspecLockPackage(
+                name: 'very_good_test_runner',
+                type: PubspecLockPackageDependencyType.directMain,
+                isPubHosted: true,
+              ),
+              PubspecLockPackage(
+                name: 'very_good_analysis',
+                type: PubspecLockPackageDependencyType.directDev,
+                isPubHosted: true,
+              ),
+              PubspecLockPackage(
+                name: 'yaml',
+                type: PubspecLockPackageDependencyType.transitive,
+                isPubHosted: true,
+              ),
+              PubspecLockPackage(
+                name: 'path',
+                type: PubspecLockPackageDependencyType.directOverridden,
+                isPubHosted: true,
+              ),
+              PubspecLockPackage(
+                name: 'foo',
+                type: PubspecLockPackageDependencyType.directMain,
+                isPubHosted: false,
+              ),
+            ],
+          ),
+        );
+      });
+
+      test('throws a $PubspecLockParseException when content is empty', () {
+        expect(
+          () => PubspecLock.fromString(''),
+          throwsA(isA<PubspecLockParseException>()),
+        );
+      });
+
+      test('returns empty PubspecLock when content has no packages entry', () {
+        final pubspecLock = PubspecLock.fromString(_emptyPubspecLockContent);
+        expect(pubspecLock.packages, isEmpty);
+      });
+    });
+  });
+
+  group('PubspecLockPackage', () {
+    test('can be instantiated', () {
+      expect(
+        PubspecLockPackage(
+          name: 'foo',
+          type: PubspecLockPackageDependencyType.directMain,
+          isPubHosted: true,
+        ),
+        isA<PubspecLockPackage>(),
+      );
+    });
+
+    test('supports value equality', () {
+      final package1 = PubspecLockPackage(
+        name: 'foo',
+        type: PubspecLockPackageDependencyType.directMain,
+        isPubHosted: true,
+      );
+      final package2 = PubspecLockPackage(
+        name: 'foo',
+        type: PubspecLockPackageDependencyType.directMain,
+        isPubHosted: true,
+      );
+      final package3 = PubspecLockPackage(
+        name: 'bar',
+        type: PubspecLockPackageDependencyType.transitive,
+        isPubHosted: false,
+      );
+
+      expect(package1, equals(package2));
+      expect(package1, isNot(equals(package3)));
+      expect(package2, isNot(equals(package3)));
+    });
+  });
+}
+
+/// An example pubspec.lock content used to test the [PubspecLock] class.
+///
+/// It has been artificially crafted to include:
+/// - one hosted direct package entry
+/// - one hosted direct dev package entry
+/// - one hosted transitive package entry
+/// - one hosted overridden package entry
+/// - one invalid package entry
+const _pubspecLockContent = '''
+packages:
+  very_good_test_runner:
+    dependency: "direct main"
+    description:
+      name: very_good_test_runner
+      sha256: "4d41e5d7677d259b9a1599c78645ac2d36bc2bd6ff7773507bcb0bab41417fe2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
+  very_good_analysis:
+    dependency: "direct dev"
+    description:
+      name: very_good_analysis
+      sha256: "9ae7f3a3bd5764fb021b335ca28a34f040cd0ab6eec00a1b213b445dae58a4b8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
+  path:
+    dependency: "direct overridden"
+    description:
+      name: path
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
+  foo:
+    dependency: "direct main"
+    description:
+      path: "packages/foo"
+      relative: true
+    source: path
+    version: "1.0.0+1"
+  bad_package:
+    not_dependency: "bad"
+sdks:
+  dart: ">=3.1.0 <4.0.0"
+
+''';
+
+/// A valid pubspec lock file with no packages.
+const _emptyPubspecLockContent = '''
+sdks:
+  dart: ">=3.1.0 <4.0.0"
+
+''';

--- a/test/src/pubspec_lock/pubspec_lock_test.dart
+++ b/test/src/pubspec_lock/pubspec_lock_test.dart
@@ -96,6 +96,45 @@ void main() {
       expect(package2, isNot(equals(package3)));
     });
   });
+
+  group('$PubspecLockPackageDependencyType', () {
+    group('parse', () {
+      test('parses successfully `direct main`', () {
+        expect(
+          PubspecLockPackageDependencyType.parse('direct main'),
+          equals(PubspecLockPackageDependencyType.directMain),
+        );
+      });
+
+      test('parses successfully `direct dev`', () {
+        expect(
+          PubspecLockPackageDependencyType.parse('direct dev'),
+          equals(PubspecLockPackageDependencyType.directDev),
+        );
+      });
+
+      test('parses successfully `direct overridden`', () {
+        expect(
+          PubspecLockPackageDependencyType.parse('direct overridden'),
+          equals(PubspecLockPackageDependencyType.directOverridden),
+        );
+      });
+
+      test('parses successfully `transitive`', () {
+        expect(
+          PubspecLockPackageDependencyType.parse('transitive'),
+          equals(PubspecLockPackageDependencyType.transitive),
+        );
+      });
+
+      test('throws a $ArgumentError when type is invalid', () {
+        expect(
+          () => PubspecLockPackageDependencyType.parse('invalid'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+  });
 }
 
 /// An example pubspec.lock content used to test the [PubspecLock] class.

--- a/test/src/pubspec_lock/pubspec_lock_test.dart
+++ b/test/src/pubspec_lock/pubspec_lock_test.dart
@@ -38,6 +38,11 @@ void main() {
                 type: PubspecLockPackageDependencyType.directMain,
                 isPubHosted: false,
               ),
+              PubspecLockPackage(
+                name: 'yaml2',
+                type: PubspecLockPackageDependencyType.transitive,
+                isPubHosted: false,
+              ),
             ],
           ),
         );
@@ -96,11 +101,12 @@ void main() {
 /// An example pubspec.lock content used to test the [PubspecLock] class.
 ///
 /// It has been artificially crafted to include:
-/// - one hosted direct package entry
-/// - one hosted direct dev package entry
-/// - one hosted transitive package entry
-/// - one hosted overridden package entry
+/// - one pub hosted direct package entry
+/// - one pub hosted direct dev package entry
+/// - one pub hosted transitive package entry
+/// - one pub hosted overridden package entry
 /// - one invalid package entry
+/// - one not pub hosted transitive package entry
 const _pubspecLockContent = '''
 packages:
   very_good_test_runner:
@@ -142,6 +148,14 @@ packages:
       relative: true
     source: path
     version: "1.0.0+1"
+  yaml2:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      url: "https://not-pub.dev"
+    source: hosted
+    version: "3.1.2"
   bad_package:
     not_dependency: "bad"
 sdks:


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

> Should be merged after #930 

## Status

**READY**

## Description

Adds support for "direct-overriden" dependency type on `very_good packages check licenses --dependency-type 'direct-overridden`.

Had to abandon the use of `pubspec_lock` since the dependency seems to not be maintained any more and overriding it caused the pana score to drop.

Somewhat related to #901 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
