### PR TITLE
ci: update workflows to use Flutter 3.22

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,7 @@ jobs:
         flutter-version:
           # The version of Flutter to use should use the minimum Dart SDK version supported by the package,
           # refer to https://docs.flutter.dev/development/tools/sdk/releases.
-          - "3.19.0"
+          - "3.22.0"
           - "3.x"
         test:
           # E2E tests for the test command

--- a/.github/workflows/very_good_cli.yaml
+++ b/.github/workflows/very_good_cli.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2.8.0
         with:
-          flutter-version: 3.19.0
+          flutter-version: 3.22.0
 
       - name: Install Dependencies
         run: flutter pub get

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -339,8 +339,10 @@ Future<int> _flutterTest({
     return result.join(' ');
   }
 
-  final timerSubscription =
-      Stream.periodic(const Duration(seconds: 1), (_) => _).listen(
+  final timerSubscription = Stream.periodic(
+    const Duration(seconds: 1),
+    (computationCount) => computationCount,
+  ).listen(
     (tick) {
       if (completer.isCompleted) return;
       final timeElapsed = Duration(seconds: tick).formatted();

--- a/lib/src/commands/create/commands/create_subcommand.dart
+++ b/lib/src/commands/create/commands/create_subcommand.dart
@@ -178,8 +178,8 @@ abstract class CreateSubCommand extends Command<int> {
         '''Building generator from brick: ${brick.name} ${brick.location.version}''',
       );
       return await _generatorFromBrick(brick);
-    } catch (_) {
-      logger.detail('Building generator from brick failed: $_');
+    } catch (error) {
+      logger.detail('Building generator from brick failed: $error');
     }
     logger.detail(
       '''Building generator from bundle ${template.bundle.name} ${template.bundle.version}''',


### PR DESCRIPTION
## Status

**READY**

## Description

Related to #1045

Changes:
- Updates workflows to use Flutter 3.22
- Updates the use of wildcards to avoid dropping pana score, and hence failing the CI

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
