### PR TITLE
fix: show a better message when coverage is really close to min coverage

### DIFF
--- a/lib/src/commands/test/test.dart
+++ b/lib/src/commands/test/test.dart
@@ -210,8 +210,23 @@ This command should be run from the root of your Flutter project.''',
           return ExitCode.unavailable.code;
         }
       } on MinCoverageNotMet catch (e) {
+        var decimalPlaces = 2;
+
+        double round(double x) {
+          final b = pow(10, decimalPlaces);
+          return (x * b).roundToDouble() / b;
+        }
+
+        if (e.coverage < minCoverage!) {
+          var rounded = round(e.coverage);
+          while (rounded == minCoverage) {
+            decimalPlaces++;
+            rounded = round(e.coverage);
+          }
+        }
+
         _logger.err(
-          '''Expected coverage >= ${minCoverage!.toStringAsFixed(2)}% but actual is ${e.coverage.toStringAsFixed(2)}%.''',
+          '''Expected coverage >= ${minCoverage.toStringAsFixed(decimalPlaces)}% but actual is ${e.coverage.toStringAsFixed(decimalPlaces)}%.''',
         );
         return ExitCode.unavailable.code;
       } catch (error) {

--- a/test/src/commands/test/test_test.dart
+++ b/test/src/commands/test/test_test.dart
@@ -413,6 +413,44 @@ void main() {
       ).called(1);
     });
 
+    test('displays required precision see why coverage was not met', () async {
+      when<dynamic>(() => argResults['coverage']).thenReturn(true);
+      when<dynamic>(() => argResults['min-coverage']).thenReturn('100');
+      const exception = MinCoverageNotMet(99.999995);
+      when(
+        () => flutterTest(
+          cwd: any(named: 'cwd'),
+          recursive: any(named: 'recursive'),
+          collectCoverage: any(named: 'collectCoverage'),
+          optimizePerformance: any(named: 'optimizePerformance'),
+          minCoverage: any(named: 'minCoverage'),
+          excludeFromCoverage: any(named: 'excludeFromCoverage'),
+          arguments: any(named: 'arguments'),
+          logger: any(named: 'logger'),
+          stdout: any(named: 'stdout'),
+          stderr: any(named: 'stderr'),
+        ),
+      ).thenThrow(exception);
+      final result = await testCommand.run();
+      expect(result, equals(ExitCode.unavailable.code));
+      verify(
+        () => flutterTest(
+          optimizePerformance: true,
+          collectCoverage: true,
+          arguments: defaultArguments,
+          minCoverage: 100,
+          logger: logger,
+          stdout: logger.write,
+          stderr: logger.err,
+        ),
+      ).called(1);
+      verify(
+        () => logger.err(
+          'Expected coverage >= 100.000000% but actual is 99.999995%.',
+        ),
+      ).called(1);
+    });
+
     test('exclude files from coverage when --exclude-coverage is used',
         () async {
       when<dynamic>(() => argResults['coverage']).thenReturn(true);


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

On our project we had one line uncovered, which gave us a coverage of 99.995%. Our minimum coverage is 100%. The message given was `Expected coverage >= 100.00% but actual is 100.00%`, which isn't very helpful. This change will still use 2 decimal places unless the actual coverage is so close that it rounds to the expected amount, and in that case will increase to an appropriate number of decimal places.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
