### PR TITLE
fix: update package path normalization in licenses command

### DIFF
--- a/lib/src/commands/packages/commands/check/commands/licenses.dart
+++ b/lib/src/commands/packages/commands/check/commands/licenses.dart
@@ -241,7 +241,7 @@ class PackagesCheckLicensesCommand extends Command<int> {
         continue;
       }
 
-      final packagePath = path.normalize(cachePackageEntry.root.path);
+      final packagePath = path.normalize(path.fromUri(cachePackageEntry.root));
       final packageDirectory = Directory(packagePath);
       if (!packageDirectory.existsSync()) {
         final errorMessage =


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

The path normalization was adding extra `\` on windows, that was making the command failing cause it never found the package in path

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in resolving package directory paths when checking for license files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->