### PR TITLE
Reorder Flutter SDK check and pubGet execution

### DIFF
--- a/lib/src/commands/packages/commands/get.dart
+++ b/lib/src/commands/packages/commands/get.dart
@@ -50,21 +50,26 @@ class PackagesGetCommand extends Command<int> {
     final target = _argResults.rest.length == 1 ? _argResults.rest[0] : '.';
     final targetPath = path.normalize(Directory(target).absolute.path);
     final isFlutterInstalled = await Flutter.installed(logger: _logger);
-    if (isFlutterInstalled) {
-      try {
-        await Flutter.pubGet(
-          cwd: targetPath,
-          recursive: recursive,
-          ignore: ignore,
-          logger: _logger,
-        );
-      } on PubspecNotFound catch (_) {
-        _logger.err('Could not find a pubspec.yaml in $targetPath');
-        return ExitCode.noInput.code;
-      } catch (error) {
-        _logger.err('$error');
-        return ExitCode.unavailable.code;
-      }
+    if (!isFlutterInstalled) {
+      _logger.err(
+        'Could not find Flutter SDK. Please ensure it is installed and '
+        'available in your PATH.',
+      );
+      return ExitCode.unavailable.code;
+    }
+    try {
+      await Flutter.pubGet(
+        cwd: targetPath,
+        recursive: recursive,
+        ignore: ignore,
+        logger: _logger,
+      );
+    } on PubspecNotFound catch (_) {
+      _logger.err('Could not find a pubspec.yaml in $targetPath');
+      return ExitCode.noInput.code;
+    } catch (error) {
+      _logger.err('$error');
+      return ExitCode.unavailable.code;
     }
     return ExitCode.success.code;
   }


### PR DESCRIPTION
## Status

**READY**

## Description

Hey very_good_ventures team,

This PR resolves #760 by ensuring the Flutter SDK is checked before executing pub get, which improves error handling for missing SDK scenarios. I also noticed that the "Flutter not installed" issue isn't handled in many scenarios. Maybe we can use this PR as a foundation to handle Flutter installation checks in other commands as well.

Let me know what you think!

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
