### PR TITLE
fix: ignore example by default when getting dependencies

### DIFF
--- a/lib/src/cli/dart_cli.dart
+++ b/lib/src/cli/dart_cli.dart
@@ -42,7 +42,7 @@ class Dart {
         try {
           return await _Cmd.run(
             'dart',
-            ['pub', 'get'],
+            ['pub', 'get', '--no-example'],
             workingDirectory: cwd,
             logger: logger,
           );

--- a/lib/src/cli/flutter_cli.dart
+++ b/lib/src/cli/flutter_cli.dart
@@ -158,7 +158,7 @@ class Flutter {
         try {
           return await _Cmd.run(
             'flutter',
-            ['pub', 'get'],
+            ['pub', 'get', '--no-example'],
             workingDirectory: cwd,
             logger: logger,
           );

--- a/test/src/commands/packages/commands/get_test.dart
+++ b/test/src/commands/packages/commands/get_test.dart
@@ -423,5 +423,217 @@ sdk: ^3.8.0
         });
       }),
     );
+
+    test(
+      'completes normally '
+      'and ignores example by default (non-recursive)',
+      withRunner((commandRunner, logger, pubUpdater, printLogs) async {
+        final tempDirectory = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+        final directoryA = Directory(path.join(tempDirectory.path, 'plugin'));
+
+        File(
+            path.join(directoryA.path, 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: plugin
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        File(
+            path.join(directoryA.path, 'example', 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: example
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        final result = await commandRunner.run([
+          'packages',
+          'get',
+          '${tempDirectory.path}/plugin',
+        ]);
+
+        expect(result, equals(ExitCode.success.code));
+        verify(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in .''',
+              ),
+            ),
+          );
+        }).called(1);
+
+        verifyNever(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in example''',
+              ),
+            ),
+          );
+        });
+      }),
+    );
+
+    test(
+      'completes normally '
+      'and does not ignore example when is recursive',
+      withRunner((commandRunner, logger, pubUpdater, printLogs) async {
+        final tempDirectory = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+        final directoryA = Directory(path.join(tempDirectory.path, 'plugin'));
+
+        File(
+            path.join(directoryA.path, 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: plugin
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        File(
+            path.join(directoryA.path, 'example', 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: example
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        final result = await commandRunner.run([
+          'packages',
+          'get',
+          '--recursive',
+          '${tempDirectory.path}/plugin',
+        ]);
+
+        expect(result, equals(ExitCode.success.code));
+
+        verify(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in . ''',
+              ),
+            ),
+          );
+        }).called(1);
+
+        verify(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in ./example''',
+              ),
+            ),
+          );
+        }).called(1);
+      }),
+    );
+
+    test(
+      'completes normally '
+      'and ignores example when using --ignore=example (recursive)',
+      withRunner((commandRunner, logger, pubUpdater, printLogs) async {
+        final tempDirectory = Directory.systemTemp.createTempSync();
+        addTearDown(() => tempDirectory.deleteSync(recursive: true));
+
+        final directoryA = Directory(path.join(tempDirectory.path, 'plugin'));
+
+        File(
+            path.join(directoryA.path, 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: plugin
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        File(
+            path.join(directoryA.path, 'example', 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: example
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        File(
+            path.join(directoryA.path, 'my_sub_package', 'pubspec.yaml'),
+          )
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+          name: my_sub_package
+          version: 0.1.0
+          
+          environment:
+            sdk: ^3.8.0
+          ''');
+
+        final result = await commandRunner.run([
+          'packages',
+          'get',
+          '--recursive',
+          '--ignore=example',
+          '${tempDirectory.path}/plugin',
+        ]);
+
+        expect(result, equals(ExitCode.success.code));
+        verify(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in . ''',
+              ),
+            ),
+          );
+        }).called(1);
+
+        verify(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in ./my_sub_package''',
+              ),
+            ),
+          );
+        }).called(1);
+
+        verifyNever(() {
+          logger.progress(
+            any(
+              that: contains(
+                '''Running "flutter pub get" in example''',
+              ),
+            ),
+          );
+        });
+      }),
+    );
   });
 }


### PR DESCRIPTION
## Status

**READY**

## Description

- fix: ignore example by default when getting dependencies, issue related [#1118].

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
