### PR TITLE
feat: Adding report-on flag to the dart test command

### DIFF
--- a/lib/src/cli/dart_cli.dart
+++ b/lib/src/cli/dart_cli.dart
@@ -110,6 +110,7 @@ class Dart {
     void Function(String)? stdout,
     void Function(String)? stderr,
     GeneratorBuilder buildGenerator = MasonGenerator.fromBundle,
+    String? reportOn,
   }) async {
     return TestCLIRunner.test(
       logger: logger,
@@ -126,6 +127,7 @@ class Dart {
       arguments: arguments,
       stdout: stdout,
       stderr: stderr,
+      reportOn: reportOn,
       buildGenerator: buildGenerator,
     );
   }

--- a/lib/src/cli/test_cli_runner.dart
+++ b/lib/src/cli/test_cli_runner.dart
@@ -78,6 +78,7 @@ class TestCLIRunner {
     void Function(String)? stdout,
     void Function(String)? stderr,
     GeneratorBuilder buildGenerator = MasonGenerator.fromBundle,
+    String? reportOn,
     @visibleForTesting VeryGoodTestRunner? overrideTestRunner,
   }) async {
     final initialCwd = cwd;
@@ -182,7 +183,7 @@ class TestCLIRunner {
 
                   final output = hitmap.formatLcov(
                     resolver,
-                    reportOn: ['lib'],
+                    reportOn: [reportOn ?? 'lib'],
                     basePath: cwd,
                   );
 

--- a/lib/src/commands/dart/commands/dart_test_command.dart
+++ b/lib/src/commands/dart/commands/dart_test_command.dart
@@ -21,6 +21,7 @@ class DartTestOptions {
     required this.optimizePerformance,
     required this.forceAnsi,
     required this.rest,
+    required this.reportOn,
   });
 
   /// Parses [ArgResults] into a [DartTestOptions] instance.
@@ -40,6 +41,7 @@ class DartTestOptions {
         : randomOrderingSeed;
     final optimizePerformance = argResults['optimization'] as bool;
     final forceAnsi = argResults['force-ansi'] as bool?;
+    final reportOn = argResults['report-on'] as String?;
     final rest = argResults.rest;
 
     return DartTestOptions._(
@@ -52,6 +54,7 @@ class DartTestOptions {
       randomSeed: randomSeed,
       optimizePerformance: optimizePerformance,
       forceAnsi: forceAnsi,
+      reportOn: reportOn,
       rest: rest,
     );
   }
@@ -84,6 +87,9 @@ class DartTestOptions {
   /// default behavior based on stdout and stderr.
   final bool? forceAnsi;
 
+  /// An optional file path to report coverage information to.
+  final String? reportOn;
+
   /// The remaining arguments passed to the `dart test` command.
   final List<String> rest;
 }
@@ -106,6 +112,7 @@ typedef DartTestCommandCall =
       List<String>? arguments,
       void Function(String)? stdout,
       void Function(String)? stderr,
+      String? reportOn,
     });
 
 /// {@template dart_test_command}
@@ -176,6 +183,13 @@ class DartTestCommand extends Command<int> {
             'Whether to force ansi output. If not specified, '
             'it will maintain the default behavior based on stdout and stderr.',
         negatable: false,
+      )
+      ..addOption(
+        'report-on',
+        help:
+            'An optional file path to report coverage information to. '
+            'This should be a path relative to the current working directory.',
+        valueHelp: 'lib/',
       );
   }
 
@@ -234,6 +248,7 @@ This command should be run from the root of your Dart project.''');
             ...['-j', options.concurrency],
             ...options.rest,
           ],
+          reportOn: options.reportOn,
         );
         if (results.any((code) => code != ExitCode.success.code)) {
           return ExitCode.unavailable.code;


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

Adds the `report-on` flag to the `very_good dart test` command. This will enable very good cli to be used in projects which the source folder is not always on the `lib` folder. (e.g. Dart Frog projects).

The same flag was not added to `very_good test` since the flutter test command will always report on the lib folder as that is hardcoded in their code.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
