### PR TITLE
feat: add support `--platform` in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ very_good test --recursive
 
 # Run tests recursively (shorthand)
 very_good test -r
+
+# Run tests on a specific platform
+very_good test --platform chrome
 ```
 
 ### [`very_good packages get`](https://cli.vgv.dev/docs/commands/get_pkgs)

--- a/lib/src/commands/dart/commands/dart_test_command.dart
+++ b/lib/src/commands/dart/commands/dart_test_command.dart
@@ -20,6 +20,7 @@ class DartTestOptions {
     required this.randomSeed,
     required this.optimizePerformance,
     required this.forceAnsi,
+    required this.platform,
     required this.rest,
     required this.reportOn,
   });
@@ -41,6 +42,7 @@ class DartTestOptions {
         : randomOrderingSeed;
     final optimizePerformance = argResults['optimization'] as bool;
     final forceAnsi = argResults['force-ansi'] as bool?;
+    final platform = argResults['platform'] as String?;
     final reportOn = argResults['report-on'] as String?;
     final rest = argResults.rest;
 
@@ -54,6 +56,7 @@ class DartTestOptions {
       randomSeed: randomSeed,
       optimizePerformance: optimizePerformance,
       forceAnsi: forceAnsi,
+      platform: platform,
       reportOn: reportOn,
       rest: rest,
     );
@@ -86,6 +89,9 @@ class DartTestOptions {
   /// Whether to force ansi output. If not specified, it will maintain the
   /// default behavior based on stdout and stderr.
   final bool? forceAnsi;
+
+  /// The platform to run tests on (e.g., 'chrome', 'vm').
+  final String? platform;
 
   /// An optional file path to report coverage information to.
   final String? reportOn;
@@ -190,6 +196,13 @@ class DartTestCommand extends Command<int> {
             'An optional file path to report coverage information to. '
             'This should be a path relative to the current working directory.',
         valueHelp: 'lib/',
+      )
+      ..addOption(
+        'platform',
+        help:
+            'The platform to run tests on. '
+            'For Dart tests, this can be "chrome", "vm", etc.',
+        valueHelp: 'chrome|vm',
       );
   }
 
@@ -245,6 +258,7 @@ This command should be run from the root of your Dart project.''');
           arguments: [
             if (options.excludeTags != null) ...['-x', options.excludeTags!],
             if (options.tags != null) ...['-t', options.tags!],
+            if (options.platform != null) ...['--platform', options.platform!],
             ...['-j', options.concurrency],
             ...options.rest,
           ],

--- a/lib/src/commands/test/test.dart
+++ b/lib/src/commands/test/test.dart
@@ -23,6 +23,7 @@ class FlutterTestOptions {
     required this.forceAnsi,
     required this.dartDefine,
     required this.dartDefineFromFile,
+    required this.platform,
     required this.rest,
   });
 
@@ -47,6 +48,7 @@ class FlutterTestOptions {
     final dartDefine = argResults['dart-define'] as List<String>?;
     final dartDefineFromFile =
         argResults['dart-define-from-file'] as List<String>?;
+    final platform = argResults['platform'] as String?;
     final rest = argResults.rest;
 
     return FlutterTestOptions._(
@@ -62,6 +64,7 @@ class FlutterTestOptions {
       forceAnsi: forceAnsi,
       dartDefine: dartDefine,
       dartDefineFromFile: dartDefineFromFile,
+      platform: platform,
       rest: rest,
     );
   }
@@ -103,6 +106,9 @@ class FlutterTestOptions {
 
   /// Optional list of dart define from files
   final List<String>? dartDefineFromFile;
+
+  /// The platform to run tests on (e.g., 'chrome', 'vm', 'android', 'ios').
+  final String? platform;
 
   /// The remaining arguments passed to the test command.
   final List<String> rest;
@@ -227,6 +233,14 @@ class TestCommand extends Command<int> {
             'Entries from "--dart-define" with identical keys take '
             'precedence over entries from these files.',
         valueHelp: 'use-define-config.json|.env',
+      )
+      ..addOption(
+        'platform',
+        help:
+            'The platform to run tests on. '
+            'For Flutter tests, this can be "chrome", "vm", "android", "ios", etc. '
+            'For Dart tests, this can be "chrome", "vm", etc.',
+        valueHelp: 'chrome|vm|android|ios',
       );
   }
 
@@ -286,6 +300,7 @@ This command should be run from the root of your Flutter project.''');
             if (options.excludeTags != null) ...['-x', options.excludeTags!],
             if (options.tags != null) ...['-t', options.tags!],
             if (options.updateGoldens) '--update-goldens',
+            if (options.platform != null) ...['--platform', options.platform!],
             if (options.dartDefine != null)
               for (final value in options.dartDefine!) '--dart-define=$value',
             if (options.dartDefineFromFile != null)

--- a/site/docs/commands/test.md
+++ b/site/docs/commands/test.md
@@ -26,6 +26,7 @@ very_good test [arguments]
     --test-randomize-ordering-seed    The seed to randomize the execution order of test cases within test files.
     --update-goldens                  Whether "matchesGoldenFile()" calls within your test methods should update the golden files.
     --force-ansi                      Whether to force ansi output. If not specified, it will maintain the default behavior based on stdout and stderr.
+    --platform                        The platform to run tests on. For Flutter tests, this can be "chrome", "vm", "android", "ios", etc. For Dart tests, this can be "chrome", "vm", etc.
     --dart-define=<foo=bar>           Additional key-value pairs that will be available as constants from the String.fromEnvironment, bool.fromEnvironment, int.fromEnvironment, and double.fromEnvironment constructors. Multiple defines can be passed by repeating "--dart-define" multiple times.
 
 Run "very_good help" to see global options.

--- a/test/src/commands/dart/commands/dart_test_test.dart
+++ b/test/src/commands/dart/commands/dart_test_test.dart
@@ -37,6 +37,7 @@ const expectedTestUsage = [
       '    --min-coverage                    Whether to enforce a minimum coverage percentage.\n'
       '    --test-randomize-ordering-seed    The seed to randomize the execution order of test cases within test files.\n'
       '    --force-ansi                      Whether to force ansi output. If not specified, it will maintain the default behavior based on stdout and stderr.\n'
+      '    --platform                        The platform to run tests on. For Dart tests, this can be "chrome", "vm", etc.\n'
       '    --report-on=<lib/>                An optional file path to report coverage information to. This should be a path relative to the current working directory.\n'
       '\n'
       'Run "very_good help" to see global options.',
@@ -239,6 +240,20 @@ void main() {
       verify(
         () => dartTest(
           arguments: defaultArguments,
+          logger: logger,
+          stdout: logger.write,
+          stderr: logger.err,
+        ),
+      ).called(1);
+    });
+
+    test('completes normally --platform chrome', () async {
+      when<dynamic>(() => argResults['platform']).thenReturn('chrome');
+      final result = await testCommand.run();
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => dartTest(
+          arguments: ['--platform', 'chrome', ...defaultArguments],
           logger: logger,
           stdout: logger.write,
           stderr: logger.err,

--- a/test/src/commands/test/test_test.dart
+++ b/test/src/commands/test/test_test.dart
@@ -38,6 +38,7 @@ const expectedTestUsage = [
       '    --test-randomize-ordering-seed                           The seed to randomize the execution order of test cases within test files.\n'
       '    --update-goldens                                         Whether "matchesGoldenFile()" calls within your test methods should update the golden files.\n'
       '    --force-ansi                                             Whether to force ansi output. If not specified, it will maintain the default behavior based on stdout and stderr.\n'
+      '    --platform                                               The platform to run tests on. For Flutter tests, this can be "chrome", "vm", "android", "ios", etc. For Dart tests, this can be "chrome", "vm", etc.\n'
       '    --dart-define=<foo=bar>                                  Additional key-value pairs that will be available as constants from the String.fromEnvironment, bool.fromEnvironment, int.fromEnvironment, and double.fromEnvironment constructors. Multiple defines can be passed by repeating "--dart-define" multiple times.\n'
       '    --dart-define-from-file=<use-define-config.json|.env>    The path of a .json or .env file containing key-value pairs that will be available as environment variables. These can be accessed using the String.fromEnvironment, bool.fromEnvironment, and int.fromEnvironment constructors. Multiple defines can be passed by repeating "--dart-define-from-file" multiple times. Entries from "--dart-define" with identical keys take precedence over entries from these files.\n'
       '\n'
@@ -255,6 +256,20 @@ void main() {
       verify(
         () => flutterTest(
           arguments: ['--update-goldens', ...defaultArguments],
+          logger: logger,
+          stdout: logger.write,
+          stderr: logger.err,
+        ),
+      ).called(1);
+    });
+
+    test('completes normally --platform chrome', () async {
+      when<dynamic>(() => argResults['platform']).thenReturn('chrome');
+      final result = await testCommand.run();
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => flutterTest(
+          arguments: ['--platform', 'chrome', ...defaultArguments],
           logger: logger,
           stdout: logger.write,
           stderr: logger.err,


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**IN DEVELOPMENT**

## Description

Adds posibility to pass platform argument into test command to be selective on which platform we want to run tests.
Very helpful when there are certain tests that have `@TestOn('browser')` tag

Once finished resolves https://github.com/VeryGoodOpenSource/very_good_cli/issues/1357

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
