### PR TITLE
feat(mcp): add directory parameter to test tool mcp

### DIFF
--- a/lib/src/mcp/mcp_server.dart
+++ b/lib/src/mcp/mcp_server.dart
@@ -135,6 +135,11 @@ If is omitted, then core will be selected.
         description: 'Run tests in a Dart or Flutter project.',
         inputSchema: ObjectSchema(
           properties: {
+            'directory': StringSchema(
+              description:
+                  'Target directory path (defaults to current directory). '
+                  'Can be absolute or relative path to project root.',
+            ),
             'dart': BooleanSchema(
               description:
                   '''Whether to run Dart tests. If not specified, Flutter tests will be run if a Flutter project is detected.''',
@@ -319,6 +324,9 @@ Only one value can be selected.
   List<String> _parseTest(Map<String, Object?> args) {
     final cliArgs = <String>[if (args['dart'] == true) 'dart', 'test'];
 
+    if (args['directory'] != null) {
+      cliArgs.add(args['directory']! as String);
+    }
     if (args['coverage'] == true) {
       cliArgs.add('--coverage');
     }
@@ -464,9 +472,7 @@ Only one value can be selected.
 
       if (exitCode == ExitCode.success.code) {
         return CallToolResult(
-          content: [
-            TextContent(text: '"$toolName" completed successfully.'),
-          ],
+          content: [TextContent(text: '"$toolName" completed successfully.')],
           isError: false,
         );
       }

--- a/test/src/mcp/mcp_server_test.dart
+++ b/test/src/mcp/mcp_server_test.dart
@@ -91,10 +91,7 @@ void main() {
         ),
       );
       registerFallbackValue(
-        CallToolRequest(
-          name: 'dummyTool',
-          arguments: const {},
-        ),
+        CallToolRequest(name: 'dummyTool', arguments: const {}),
       );
 
       when(
@@ -301,10 +298,7 @@ void main() {
         await sendRequest(
           CallToolRequest.methodName,
           _params(
-            CallToolRequest(
-              name: 'test',
-              arguments: {'optimization': false},
-            ),
+            CallToolRequest(name: 'test', arguments: {'optimization': false}),
           ),
         );
 
@@ -374,6 +368,40 @@ void main() {
           '--run-skipped',
           '--check-ignore',
         ]);
+      });
+
+      test('passes directory as positional argument', () async {
+        await sendRequest(
+          CallToolRequest.methodName,
+          _params(
+            CallToolRequest(
+              name: 'test',
+              arguments: {'directory': 'my_dir'},
+            ),
+          ),
+        );
+
+        final capturedArgs =
+            verify(() => mockCommandRunner.run(captureAny())).captured.first
+                as List<String>;
+        expect(capturedArgs, ['test', 'my_dir']);
+      });
+
+      test('passes directory as positional argument with dart flag', () async {
+        await sendRequest(
+          CallToolRequest.methodName,
+          _params(
+            CallToolRequest(
+              name: 'test',
+              arguments: {'directory': 'my_dir', 'dart': true},
+            ),
+          ),
+        );
+
+        final capturedArgs =
+            verify(() => mockCommandRunner.run(captureAny())).captured.first
+                as List<String>;
+        expect(capturedArgs, ['dart', 'test', 'my_dir']);
       });
 
       test('handles command failure', () async {


### PR DESCRIPTION
The test MCP tool was missing a directory parameter that packages_get and packages_check_licenses already supported. This adds it as a positional argument passed through to the test runner.

<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
