### PR TITLE
chore(ci): use flutter-action on spdx_license_bot

### DIFF
--- a/.github/workflows/spdx_license_bot.yaml
+++ b/.github/workflows/spdx_license_bot.yaml
@@ -20,10 +20,10 @@ jobs:
       - name: 📚 Git Checkout
         uses: actions/checkout@v6
 
-      - name: 🎯 Setup Dart
-        uses: dart-lang/setup-dart@v1
+      - name: 🐦 Setup Flutter
+        uses: subosito/flutter-action@v2.8.0
         with:
-          sdk: "3.11.0"
+          flutter-version: "3.41.x"
 
       - name: 📦 Install Dependencies
         run: dart pub get


### PR DESCRIPTION
<!--
  Thanks for contributing!
  Provide a description of your changes below and a general summary in the title
  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->
The bot uses `dart-lang/setup-dart@v1` pinned to `3.11.0`, the main CI uses `subosito/flutter-action@v2.8.0` pinned to `3.41.x`. Different toolchains, different bundled dart_style, opposite output on those enums. This uses same versioning for both envs.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
