### PR TITLE
feat(create): add pub workspace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ dart pub global run very_good_cli:very_good <command> <args>
 
 Create a very good project in seconds based on the provided template. Each template has a corresponding sub-command (e.g.,`very_good create flutter_app` will generate a Flutter starter app).
 
+> 🆕 **Multi-package workspaces**: use `very_good create workspace` to scaffold a
+> [pub workspace](https://dart.dev/tools/pub/workspaces), then add members with
+> the opt-in `--workspace` flag on any `create` subcommand. See
+> [Workspaces](#workspaces) below.
+
 ![Very Good Create][very_good_create]
 
 ```sh
@@ -65,6 +70,7 @@ Available subcommands:
   flutter_app       Generate a Very Good Flutter application.
   flutter_package   Generate a Very Good Flutter package.
   flutter_plugin    Generate a Very Good Flutter plugin.
+  workspace         Generate a Very Good multi-package workspace.
 
 Run "very_good help" to see global options.
 ```
@@ -111,6 +117,23 @@ very_good create flutter_plugin my_flutter_plugin --desc "My new Flutter plugin"
 # Create a new docs site named my_docs_site
 very_good create docs_site my_docs_site
 
+```
+
+#### Workspaces
+
+`very_good create workspace` scaffolds a multi-package [pub workspace][pub_workspaces_link] — a root `pubspec.yaml` with a `workspace:` list plus `apps/` and `packages/` directories for its members.
+
+```sh
+# Create a new multi-package workspace named my_workspace
+very_good create workspace my_workspace
+```
+
+Add members from inside the workspace with the opt-in `--workspace` flag (available on every `create` subcommand, off by default). It registers the new package in the root `workspace:` list and gives it `resolution: workspace`, so a single resolve covers the whole workspace:
+
+```sh
+cd my_workspace
+very_good create dart_package my_package -o packages --workspace
+very_good create flutter_app my_app -o apps --workspace
 ```
 
 ---
@@ -250,3 +273,4 @@ Run "very_good help <command>" for more information about a command.
 [very_good_create]: https://raw.githubusercontent.com/VeryGoodOpenSource/very_good_cli/main/doc/assets/very_good_create.gif
 [very_good_ventures_link]: https://verygood.ventures
 [path_setup_link]: https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path
+[pub_workspaces_link]: https://dart.dev/tools/pub/workspaces

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -91,7 +91,7 @@ Creates a new Dart or Flutter project from a template.
 {
   "tool": "create",
   "arguments": {
-    "subcommand": "flutter_app | flutter_package | flutter_plugin | flame_game | dart_cli | dart_package | docs_site | app_ui_package",
+    "subcommand": "flutter_app | flutter_package | flutter_plugin | flame_game | dart_cli | dart_package | docs_site | app_ui_package | workspace",
     "name": "my_app",
     "description": "A Very Good Project created by Very Good CLI.",
     "org_name": "com.example.verygoodcore",

--- a/lib/src/commands/create/commands/commands.dart
+++ b/lib/src/commands/create/commands/commands.dart
@@ -7,3 +7,4 @@ export 'flame_game.dart';
 export 'flutter_app.dart';
 export 'flutter_package.dart';
 export 'flutter_plugin.dart';
+export 'workspace.dart';

--- a/lib/src/commands/create/commands/create_subcommand.dart
+++ b/lib/src/commands/create/commands/create_subcommand.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:very_good_cli/src/commands/commands.dart';
 import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/workspace/workspace.dart';
 
 // A valid Dart identifier that can be used for a package, i.e. no
 // capital letters.
@@ -47,7 +48,12 @@ abstract class CreateSubCommand extends Command<int> {
   CreateSubCommand({
     required this.logger,
     @visibleForTesting required MasonGeneratorFromBundle? generatorFromBundle,
-  }) : _generatorFromBundle = generatorFromBundle ?? MasonGenerator.fromBundle {
+    @visibleForTesting WorkspaceDetector? workspaceDetector,
+    @visibleForTesting WorkspaceIntegrator? workspaceIntegrator,
+  }) : _generatorFromBundle = generatorFromBundle ?? MasonGenerator.fromBundle,
+       _workspaceDetector = workspaceDetector ?? const WorkspaceDetector(),
+       _workspaceIntegrator =
+           workspaceIntegrator ?? const WorkspaceIntegrator() {
     argParser
       ..addOption(
         'output-directory',
@@ -60,6 +66,17 @@ abstract class CreateSubCommand extends Command<int> {
         aliases: ['desc'],
         defaultsTo: _defaultDescription,
       );
+
+    // Add the opt-in workspace wiring flag for templates that can be a member
+    // of a pub workspace.
+    if (registersInWorkspace) {
+      // Opt-in (defaults to false): never modify the workspace unless the user
+      // explicitly passes --workspace.
+      argParser.addFlag(
+        'workspace',
+        help: 'Register the new package in the surrounding pub workspace.',
+      );
+    }
 
     // Add the templates arg if the command has multiple templates.
     if (this is MultiTemplates) {
@@ -104,6 +121,17 @@ abstract class CreateSubCommand extends Command<int> {
   /// The logger user to notify the user of the command's progress.
   final Logger logger;
   final MasonGeneratorFromBundle _generatorFromBundle;
+  final WorkspaceDetector _workspaceDetector;
+  final WorkspaceIntegrator _workspaceIntegrator;
+
+  /// Whether the generated project should be registered as a member of the
+  /// surrounding [pub workspace][1] (if any) after creation.
+  ///
+  /// Defaults to `true`. Subclasses that create a workspace themselves should
+  /// override this to `false` to avoid registering a workspace inside another.
+  ///
+  /// [1]: https://dart.dev/tools/pub/workspaces
+  bool get registersInWorkspace => true;
 
   /// [ArgResults] which can be overridden for testing.
   @visibleForTesting
@@ -226,7 +254,37 @@ abstract class CreateSubCommand extends Command<int> {
 
     await template.onGenerateComplete(logger, outputDirectory);
 
+    if (registersInWorkspace && _workspaceWiringRequested) {
+      _registerInWorkspace();
+    }
+
     return ExitCode.success.code;
+  }
+
+  /// Whether the user opted in to workspace wiring via `--workspace`.
+  bool get _workspaceWiringRequested =>
+      argResults['workspace'] as bool? ?? false;
+
+  /// Registers the generated project as a member of the surrounding pub
+  /// workspace, if one is detected. No-op when the project is not created
+  /// inside a workspace.
+  void _registerInWorkspace() {
+    final workspace = _workspaceDetector.detect(outputDirectory.parent);
+    if (workspace == null) return;
+
+    final member = _workspaceIntegrator.addPackage(
+      workspaceRoot: Directory(workspace.rootPath),
+      packageDirectory: outputDirectory,
+    );
+    if (member == null) return;
+
+    // Ensure the new package participates in the workspace's shared
+    // resolution, so the workspace resolves without a manual edit.
+    _workspaceIntegrator.ensureWorkspaceResolution(
+      File(path.join(outputDirectory.path, 'pubspec.yaml')),
+    );
+
+    logger.info('Added "$member" to the workspace at ${workspace.rootPath}.');
   }
 
   /// Responsible for returns the template parameters to be passed to the

--- a/lib/src/commands/create/commands/workspace.dart
+++ b/lib/src/commands/create/commands/workspace.dart
@@ -1,0 +1,26 @@
+import 'package:very_good_cli/src/commands/commands.dart';
+import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+
+/// {@template very_good_create_workspace_command}
+/// A [CreateSubCommand] for creating multi-package workspaces.
+/// {@endtemplate}
+class CreateWorkspace extends CreateSubCommand {
+  /// {@macro very_good_create_workspace_command}
+  CreateWorkspace({required super.logger, required super.generatorFromBundle});
+
+  @override
+  String get name => 'workspace';
+
+  @override
+  List<String> get aliases => ['ws'];
+
+  @override
+  String get description => 'Generate a Very Good multi-package workspace.';
+
+  // A workspace must not register itself as a member of another workspace.
+  @override
+  bool get registersInWorkspace => false;
+
+  @override
+  Template get template => VeryGoodWorkspaceTemplate();
+}

--- a/lib/src/commands/create/create.dart
+++ b/lib/src/commands/create/create.dart
@@ -78,6 +78,14 @@ class CreateCommand extends Command<int> {
         generatorFromBundle: generatorFromBundle,
       ),
     );
+
+    // very_good create workspace <args>
+    addSubcommand(
+      CreateWorkspace(
+        logger: logger,
+        generatorFromBundle: generatorFromBundle,
+      ),
+    );
   }
 
   @override

--- a/lib/src/commands/create/templates/templates.dart
+++ b/lib/src/commands/create/templates/templates.dart
@@ -8,3 +8,4 @@ export 'very_good_docs_site/very_good_docs_site.dart';
 export 'very_good_flame_game/very_good_flame_game.dart';
 export 'very_good_flutter_package/very_good_flutter_package.dart';
 export 'very_good_flutter_plugin/very_good_flutter_plugin.dart';
+export 'very_good_workspace/very_good_workspace.dart';

--- a/lib/src/commands/create/templates/very_good_workspace/very_good_workspace.dart
+++ b/lib/src/commands/create/templates/very_good_workspace/very_good_workspace.dart
@@ -1,0 +1,2 @@
+export 'very_good_workspace_bundle.dart';
+export 'very_good_workspace_template.dart';

--- a/lib/src/commands/create/templates/very_good_workspace/very_good_workspace_bundle.dart
+++ b/lib/src/commands/create/templates/very_good_workspace/very_good_workspace_bundle.dart
@@ -1,0 +1,54 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
+
+import 'package:mason/mason.dart';
+
+final veryGoodWorkspaceBundle = MasonBundle.fromJson(<String, dynamic>{
+  "files": [
+    {
+      "path": ".gitignore",
+      "data":
+          "IyBEYXJ0L0ZsdXR0ZXIKLmRhcnRfdG9vbC8KLnBhY2thZ2VzCmJ1aWxkLwpwdWJzcGVjLmxvY2sKCiMgQ292ZXJhZ2UKY292ZXJhZ2UvCgojIElERQouaWRlYS8KLnZzY29kZS8KKi5pbWwKCiMgbWFjT1MKLkRTX1N0b3JlCg==",
+      "type": "text",
+    },
+    {
+      "path": "analysis_options.yaml",
+      "data":
+          "aW5jbHVkZTogcGFja2FnZTp2ZXJ5X2dvb2RfYW5hbHlzaXMvYW5hbHlzaXNfb3B0aW9ucy55YW1sCg==",
+      "type": "text",
+    },
+    {"path": "apps/.gitkeep", "data": "", "type": "text"},
+    {"path": "packages/.gitkeep", "data": "", "type": "text"},
+    {
+      "path": "pubspec.yaml",
+      "data":
+          "bmFtZToge3twcm9qZWN0X25hbWUuc25ha2VDYXNlKCl9fQpkZXNjcmlwdGlvbjoge3tkZXNjcmlwdGlvbn19CnZlcnNpb246IDAuMS4wKzEKcHVibGlzaF90bzogbm9uZQoKZW52aXJvbm1lbnQ6CiAgc2RrOiBeMy4xMi4wCgpkZXZfZGVwZW5kZW5jaWVzOgogIHZlcnlfZ29vZF9hbmFseXNpczogXjEwLjAuMAoKIyBNZW1iZXIgcGFja2FnZXMgb2YgdGhpcyB3b3Jrc3BhY2UuIEFkZCBwYWNrYWdlcyB3aXRoCiMgYHZlcnlfZ29vZCBjcmVhdGUgPHN1YmNvbW1hbmQ+IDxuYW1lPiAtbyA8ZGlyPiAtLXdvcmtzcGFjZWAgYW5kIHRoZWlyIHBhdGhzCiMgYXJlIGFwcGVuZGVkIGhlcmUgYXV0b21hdGljYWxseS4Kd29ya3NwYWNlOiBbXQo=",
+      "type": "text",
+    },
+    {
+      "path": "README.md",
+      "data":
+          "IyB7e3Byb2plY3RfbmFtZS50aXRsZUNhc2UoKX19Cgp7e2Rlc2NyaXB0aW9ufX0KCkEgW0RhcnQvRmx1dHRlciBwdWIgd29ya3NwYWNlXVtwdWJfd29ya3NwYWNlc19saW5rXSBtYW5hZ2VkIHdpdGggW1ZlcnkgR29vZCBDTEldW3ZlcnlfZ29vZF9jbGlfbGlua10uCgotLS0KCiMjIEdldHRpbmcgU3RhcnRlZCDwn5qACgpUaGlzIHJlcG9zaXRvcnkgaXMgYSBtdWx0aS1wYWNrYWdlIHdvcmtzcGFjZS4gTWVtYmVyIHBhY2thZ2VzIGxpdmUgdW5kZXIKYGFwcHMvYCBhbmQgYHBhY2thZ2VzL2AgYW5kIHNoYXJlIGEgc2luZ2xlIGRlcGVuZGVuY3kgcmVzb2x1dGlvbi4KCkFkZCBhIG5ldyBwYWNrYWdlIHdpdGggYC0td29ya3NwYWNlYCB0byByZWdpc3RlciBpdCBpbiB0aGlzIHdvcmtzcGFjZSwgYW5kIHVzZQpgLW9gIHRvIGNob29zZSB0aGUgZGVzdGluYXRpb24gZGlyZWN0b3J5OgoKYGBgc2gKIyBBIEZsdXR0ZXIgYXBwIHVuZGVyIGFwcHMvCnZlcnlfZ29vZCBjcmVhdGUgZmx1dHRlcl9hcHAgbXlfYXBwIC1vIGFwcHMgLS13b3Jrc3BhY2UKCiMgQSByZXVzYWJsZSBEYXJ0IHBhY2thZ2UgdW5kZXIgcGFja2FnZXMvCnZlcnlfZ29vZCBjcmVhdGUgZGFydF9wYWNrYWdlIG15X3BhY2thZ2UgLW8gcGFja2FnZXMgLS13b3Jrc3BhY2UKYGBgCgpgLS13b3Jrc3BhY2VgIGFwcGVuZHMgdGhlIG5ldyBwYWNrYWdlIHRvIHRoZSBgd29ya3NwYWNlOmAgbGlzdCBpbiB0aGUgcm9vdApgcHVic3BlYy55YW1sYC4gT21pdCBpdCB0byBjcmVhdGUgYSBzdGFuZGFsb25lIHBhY2thZ2UgdGhhdCBpcyBub3Qgd2lyZWQgaW50bwp0aGUgd29ya3NwYWNlLgoKVGhlbiBmZXRjaCBkZXBlbmRlbmNpZXMgZm9yIHRoZSB3aG9sZSB3b3Jrc3BhY2UgYXQgb25jZToKCmBgYHNoCmZsdXR0ZXIgcHViIGdldApgYGAKCiMjIExheW91dAoKYGBgCnt7cHJvamVjdF9uYW1lLnNuYWtlQ2FzZSgpfX0vCuKUnOKUgOKUgCBhcHBzLyAgICAgICAgIyBSdW5uYWJsZSBhcHBsaWNhdGlvbnMK4pSc4pSA4pSAIHBhY2thZ2VzLyAgICAjIFJldXNhYmxlIHBhY2thZ2VzIHNoYXJlZCBhY3Jvc3MgYXBwcwrilJTilIDilIAgcHVic3BlYy55YW1sICMgV29ya3NwYWNlIHJvb3QgKGxpc3RzIGFsbCBtZW1iZXJzIHVuZGVyIGB3b3Jrc3BhY2U6YCkKYGBgCgpbcHViX3dvcmtzcGFjZXNfbGlua106IGh0dHBzOi8vZGFydC5kZXYvdG9vbHMvcHViL3dvcmtzcGFjZXMKW3ZlcnlfZ29vZF9jbGlfbGlua106IGh0dHBzOi8vY2xpLnZndi5kZXYK",
+      "type": "text",
+    },
+  ],
+  "hooks": [],
+  "name": "very_good_workspace",
+  "description": "A Very Good multi-package Dart/Flutter workspace.",
+  "version": "0.1.0+1",
+  "environment": {"mason": ">=0.1.0 <0.2.0"},
+  "vars": {
+    "project_name": {
+      "type": "string",
+      "description": "The workspace name.",
+      "default": "my_workspace",
+      "prompt": "What is the workspace name?",
+    },
+    "description": {
+      "type": "string",
+      "description": "The description for this new workspace.",
+      "default": "A Very Good workspace created by Very Good CLI.",
+      "prompt": "What is the workspace description?",
+    },
+  },
+});

--- a/lib/src/commands/create/templates/very_good_workspace/very_good_workspace_template.dart
+++ b/lib/src/commands/create/templates/very_good_workspace/very_good_workspace_template.dart
@@ -1,0 +1,35 @@
+import 'package:mason/mason.dart';
+import 'package:universal_io/io.dart';
+import 'package:very_good_cli/src/commands/create/templates/templates.dart';
+import 'package:very_good_cli/src/logger_extension.dart';
+
+/// {@template very_good_workspace_template}
+/// A multi-package Dart/Flutter workspace template.
+/// {@endtemplate}
+class VeryGoodWorkspaceTemplate extends Template {
+  /// {@macro very_good_workspace_template}
+  VeryGoodWorkspaceTemplate()
+    : super(
+        name: 'workspace',
+        bundle: veryGoodWorkspaceBundle,
+        help: 'Generate a Very Good multi-package workspace.',
+      );
+
+  @override
+  Future<void> onGenerateComplete(Logger logger, Directory outputDir) async {
+    _logSummary(logger);
+  }
+
+  void _logSummary(Logger logger) {
+    logger
+      ..info('\n')
+      ..created('Created a Very Good Workspace! 🦄')
+      ..info('\n')
+      ..info(
+        'Add member packages from the workspace root with '
+        '"very_good create <subcommand>" and they will be registered '
+        'automatically.',
+      )
+      ..info('\n');
+  }
+}

--- a/lib/src/mcp/mcp_server.dart
+++ b/lib/src/mcp/mcp_server.dart
@@ -96,6 +96,7 @@ flame_game - Generate a Very Good Flame game.
 flutter_app - Generate a Very Good Flutter application.
 flutter_package - Generate a Very Good Flutter package.
 flutter_plugin - Generate a Very Good Flutter plugin.
+workspace - Generate a Very Good multi-package workspace.
 ''',
               values: [
                 'app_ui_package',
@@ -106,6 +107,7 @@ flutter_plugin - Generate a Very Good Flutter plugin.
                 'dart_cli',
                 'dart_package',
                 'docs_site',
+                'workspace',
               ],
             ),
             'name': StringSchema(description: 'Project name'),

--- a/lib/src/workspace/workspace.dart
+++ b/lib/src/workspace/workspace.dart
@@ -1,0 +1,3 @@
+export 'workspace_context.dart';
+export 'workspace_detector.dart';
+export 'workspace_integrator.dart';

--- a/lib/src/workspace/workspace_context.dart
+++ b/lib/src/workspace/workspace_context.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+/// {@template workspace_context}
+/// Describes a Dart/Flutter [pub workspace][1] discovered on disk.
+///
+/// A workspace is identified by a `pubspec.yaml` that declares a top-level
+/// `workspace:` key listing its member packages.
+///
+/// [1]: https://dart.dev/tools/pub/workspaces
+/// {@endtemplate}
+class WorkspaceContext extends Equatable {
+  /// {@macro workspace_context}
+  const WorkspaceContext({required this.rootPath, required this.members});
+
+  /// The absolute path to the directory containing the workspace's
+  /// root `pubspec.yaml`.
+  final String rootPath;
+
+  /// The member package paths declared under the `workspace:` key,
+  /// relative to [rootPath] and using forward slashes.
+  final List<String> members;
+
+  @override
+  List<Object?> get props => [rootPath, members];
+}

--- a/lib/src/workspace/workspace_detector.dart
+++ b/lib/src/workspace/workspace_detector.dart
@@ -1,0 +1,49 @@
+import 'package:path/path.dart' as path;
+import 'package:universal_io/io.dart';
+import 'package:very_good_cli/src/workspace/workspace_context.dart';
+import 'package:yaml/yaml.dart';
+
+/// {@template workspace_detector}
+/// Locates the Dart/Flutter [pub workspace][1] that a directory belongs to.
+///
+/// Starting from a given directory, it walks up the directory tree until it
+/// finds a `pubspec.yaml` declaring a top-level `workspace:` key. Member
+/// packages (which declare `resolution: workspace` instead) are skipped, so
+/// detection from anywhere inside a workspace resolves to its root.
+///
+/// [1]: https://dart.dev/tools/pub/workspaces
+/// {@endtemplate}
+class WorkspaceDetector {
+  /// {@macro workspace_detector}
+  const WorkspaceDetector();
+
+  /// Returns the [WorkspaceContext] for the workspace containing [from], or
+  /// `null` if [from] is not inside a workspace.
+  WorkspaceContext? detect(Directory from) {
+    var directory = from.absolute;
+
+    while (true) {
+      final pubspec = File(path.join(directory.path, 'pubspec.yaml'));
+      if (pubspec.existsSync()) {
+        final context = _contextFor(directory, pubspec);
+        if (context != null) return context;
+      }
+
+      final parent = directory.parent;
+      if (path.equals(parent.path, directory.path)) return null;
+      directory = parent;
+    }
+  }
+
+  WorkspaceContext? _contextFor(Directory directory, File pubspec) {
+    final dynamic yaml = loadYaml(pubspec.readAsStringSync());
+    if (yaml is! YamlMap || !yaml.containsKey('workspace')) return null;
+
+    final workspace = yaml['workspace'];
+    final members = workspace is YamlList
+        ? workspace.map((dynamic e) => '$e').toList()
+        : <String>[];
+
+    return WorkspaceContext(rootPath: directory.path, members: members);
+  }
+}

--- a/lib/src/workspace/workspace_integrator.dart
+++ b/lib/src/workspace/workspace_integrator.dart
@@ -1,0 +1,114 @@
+import 'package:path/path.dart' as path;
+import 'package:universal_io/io.dart';
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+/// {@template workspace_integrator}
+/// Registers a package as a member of a Dart/Flutter [pub workspace][1] by
+/// adding its path to the `workspace:` list in the workspace's `pubspec.yaml`.
+///
+/// Edits are made with `yaml_edit` so existing formatting and comments are
+/// preserved.
+///
+/// [1]: https://dart.dev/tools/pub/workspaces
+/// {@endtemplate}
+class WorkspaceIntegrator {
+  /// {@macro workspace_integrator}
+  const WorkspaceIntegrator();
+
+  /// Adds [packageDirectory] to the `workspace:` list of the workspace rooted
+  /// at [workspaceRoot].
+  ///
+  /// Returns the relative member path that was added, or `null` if no change
+  /// was made — either because the package is already a member, or because it
+  /// lies outside [workspaceRoot].
+  String? addPackage({
+    required Directory workspaceRoot,
+    required Directory packageDirectory,
+  }) {
+    final relative = path.relative(
+      packageDirectory.absolute.path,
+      from: workspaceRoot.absolute.path,
+    );
+    final member = path.split(relative).join('/');
+
+    // Refuse to register the workspace root itself or anything outside it.
+    if (member == '.' || member.startsWith('..')) return null;
+
+    final pubspecFile = File(path.join(workspaceRoot.path, 'pubspec.yaml'));
+    final editor = YamlEditor(pubspecFile.readAsStringSync());
+
+    final members = _members(editor);
+    if (members.contains(member)) return null;
+
+    if (members.isEmpty) {
+      // Replaces a missing or empty `workspace:` value with a fresh block
+      // list, ensuring clean block-style formatting on the first member.
+      editor.update(['workspace'], [member]);
+    } else {
+      editor.appendToList(['workspace'], member);
+    }
+
+    pubspecFile.writeAsStringSync(editor.toString());
+    return member;
+  }
+
+  /// Ensures the package at [packagePubspec] declares `resolution: workspace`
+  /// so it participates in the surrounding workspace's shared resolution.
+  ///
+  /// Returns `true` if the file was modified.
+  bool ensureWorkspaceResolution(File packagePubspec) {
+    if (!packagePubspec.existsSync()) return false;
+
+    final editor = YamlEditor(packagePubspec.readAsStringSync());
+    final existing = editor.parseAt(
+      ['resolution'],
+      orElse: () => wrapAsYamlNode(null),
+    );
+    if (existing.value == 'workspace') return false;
+
+    editor.update(['resolution'], 'workspace');
+    packagePubspec.writeAsStringSync(editor.toString());
+    return true;
+  }
+
+  /// Adds a path dependency on [packageName] (resolved at [relativePath],
+  /// using forward slashes) to the `dependencies:` of [appPubspec].
+  ///
+  /// Returns `true` if the dependency was added, or `false` if it was already
+  /// present.
+  bool addPathDependency({
+    required File appPubspec,
+    required String packageName,
+    required String relativePath,
+  }) {
+    final editor = YamlEditor(appPubspec.readAsStringSync());
+
+    final dependencies = editor.parseAt(
+      ['dependencies'],
+      orElse: () => wrapAsYamlNode(null),
+    );
+    if (dependencies is YamlMap && dependencies.containsKey(packageName)) {
+      return false;
+    }
+
+    if (dependencies is! YamlMap) {
+      editor.update(['dependencies'], <String, dynamic>{});
+    }
+    editor.update(['dependencies', packageName], {'path': relativePath});
+
+    appPubspec.writeAsStringSync(editor.toString());
+    return true;
+  }
+
+  List<String> _members(YamlEditor editor) {
+    // `orElse` handles an absent `workspace:` key without throwing.
+    final node = editor.parseAt([
+      'workspace',
+    ], orElse: () => wrapAsYamlNode(null));
+    if (node is YamlList) {
+      return node.map((dynamic e) => '$e').toList();
+    }
+    return [];
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   universal_io: ^2.2.2
   very_good_test_runner: ^0.3.0
   yaml: ^3.1.2
+  yaml_edit: ^2.2.0
 
 dev_dependencies:
   build_runner: ^2.4.12

--- a/site/docs/commands/create.md
+++ b/site/docs/commands/create.md
@@ -24,6 +24,7 @@ Available subcommands:
   flutter_app       Generate a Very Good Flutter application.
   flutter_package   Generate a Very Good Flutter package.
   flutter_plugin    Generate a Very Good Flutter plugin.
+  workspace         Generate a Very Good multi-package workspace.
 
 Run "very_good help" to see global options.
 ```
@@ -81,3 +82,29 @@ and examples, see the individual template pages:
 - [Flame Game](../templates/flame_game.md) — `flame_game`
 - [App UI Package](../templates/app_ui_package.md) — `app_ui_package`
 - [Docs Site](../templates/docs_site.md) — `docs_site`
+
+## Workspaces
+
+`very_good create workspace <name>` scaffolds a multi-package
+[pub workspace](https://dart.dev/tools/pub/workspaces) — a root `pubspec.yaml`
+with a `workspace:` list plus `apps/` and `packages/` directories for its
+members.
+
+```sh
+very_good create workspace my_workspace
+```
+
+Add members from inside the workspace with the `--workspace` flag. It registers
+the new package in the root `workspace:` list and gives it
+`resolution: workspace`, so a single `very_good packages get` at the root
+resolves everything:
+
+```sh
+cd my_workspace
+very_good create dart_package my_package -o packages --workspace
+very_good create flutter_app  my_app     -o apps     --workspace
+```
+
+The `--workspace` / `--no-workspace` flag is available on every template
+subcommand. It defaults to off and is a no-op when you are not inside a
+workspace.

--- a/site/docs/overview.md
+++ b/site/docs/overview.md
@@ -61,6 +61,7 @@ Available subcommands:
   flutter_app       Generate a Very Good Flutter application.
   flutter_package   Generate a Very Good Flutter package.
   flutter_plugin    Generate a Very Good Flutter plugin.
+  workspace         Generate a Very Good multi-package workspace.
 
 Run "very_good help" to see global options.
 ```

--- a/test/helpers/test_multi_template_commands.dart
+++ b/test/helpers/test_multi_template_commands.dart
@@ -35,9 +35,11 @@ Future<void> testMultiTemplateCommand({
   when(
     () => argResults['output-directory'] as String?,
   ).thenReturn(outputDirectory.path);
+  when(() => argResults.wasParsed('org-name')).thenReturn(false);
 
   for (final entry in mockArgs.entries) {
     when(() => argResults[entry.key]).thenReturn(entry.value);
+    when(() => argResults.wasParsed(entry.key)).thenReturn(true);
   }
 
   when(() => argResults.rest).thenReturn(['my_app']);

--- a/test/src/commands/create/commands/dart_cli_test.dart
+++ b/test/src/commands/create/commands/dart_cli_test.dart
@@ -33,6 +33,7 @@ Usage: very_good create dart_cli <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --publishable         Whether the generated project is intended to be published.
     --executable-name     The CLI executable name (defaults to the project name)
 

--- a/test/src/commands/create/commands/dart_package_test.dart
+++ b/test/src/commands/create/commands/dart_package_test.dart
@@ -33,6 +33,7 @@ Usage: very_good create dart_package <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --publishable         Whether the generated project is intended to be published.
 
 Run "very_good help" to see global options.''',

--- a/test/src/commands/create/commands/docs_site_test.dart
+++ b/test/src/commands/create/commands/docs_site_test.dart
@@ -33,6 +33,7 @@ Usage: very_good create docs_site <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --publishable         Whether the generated project is intended to be published.
     --org-name            The organization for this new project.
                           (defaults to "my-org")
@@ -173,6 +174,7 @@ void main() {
           () => argResults['output-directory'] as String?,
         ).thenReturn(tempDirectory.path);
         when(() => argResults.rest).thenReturn(['my_docs_site']);
+        when(() => argResults.wasParsed('org-name')).thenReturn(true);
         when(
           () => argResults['org-name'] as String?,
         ).thenReturn('VeryGoodOpenSource');

--- a/test/src/commands/create/commands/flame_game_test.dart
+++ b/test/src/commands/create/commands/flame_game_test.dart
@@ -36,6 +36,7 @@ final expectedUsage = [
       '-o, --output-directory           The desired output directory when creating a new project.\n'
       '    --description                The description for this new project.\n'
       '                                 (defaults to "A Very Good Project created by Very Good CLI.")\n'
+      '    --[no-]workspace             Register the new package in the surrounding pub workspace.\n'
       '    --org-name                   The organization for this new project.\n'
       '                                 (defaults to "com.example.verygoodcore")\n'
       '    --publishable                Whether the generated project is intended to be published.\n'
@@ -178,6 +179,7 @@ void main() {
           logger: logger,
           generatorFromBundle: (_) async => generator,
         )..argResultOverrides = argResults;
+        when(() => argResults.wasParsed('org-name')).thenReturn(false);
         when(
           () => argResults['output-directory'] as String?,
         ).thenReturn(tempDirectory.path);

--- a/test/src/commands/create/commands/flutter_app_test.dart
+++ b/test/src/commands/create/commands/flutter_app_test.dart
@@ -31,6 +31,7 @@ Usage: very_good create flutter_app <project-name> [arguments]
 -o, --output-directory           The desired output directory when creating a new project.
     --description                The description for this new project.
                                  (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace             Register the new package in the surrounding pub workspace.
 -t, --template                   The template used to generate this new project.
 
           [core] (default)       Generate a Very Good Flutter application.

--- a/test/src/commands/create/commands/flutter_package_test.dart
+++ b/test/src/commands/create/commands/flutter_package_test.dart
@@ -33,6 +33,7 @@ Usage: very_good create flutter_package <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --publishable         Whether the generated project is intended to be published.
 
 Run "very_good help" to see global options.''',

--- a/test/src/commands/create/commands/flutter_plugin_test.dart
+++ b/test/src/commands/create/commands/flutter_plugin_test.dart
@@ -50,6 +50,7 @@ final expectedUsage = [
       '-o, --output-directory           The desired output directory when creating a new project.\n'
       '    --description                The description for this new project.\n'
       '                                 (defaults to "A Very Good Project created by Very Good CLI.")\n'
+      '    --[no-]workspace             Register the new package in the surrounding pub workspace.\n'
       '    --org-name                   The organization for this new project.\n'
       '                                 (defaults to "com.example.verygoodcore")\n'
       '    --publishable                Whether the generated project is intended to be published.\n'
@@ -195,6 +196,7 @@ void main() {
           logger: logger,
           generatorFromBundle: (_) async => generator,
         )..argResultOverrides = argResults;
+        when(() => argResults.wasParsed('org-name')).thenReturn(false);
         when(
           () => argResults['output-directory'] as String?,
         ).thenReturn(tempDirectory.path);
@@ -296,6 +298,7 @@ void main() {
             generatorFromBundle: (_) async => generator,
           )..argResultOverrides = argResults;
 
+          when(() => argResults.wasParsed('org-name')).thenReturn(false);
           when(
             () => argResults['output-directory'] as String?,
           ).thenReturn(tempDirectory.path);

--- a/test/src/commands/create/commands/workspace_test.dart
+++ b/test/src/commands/create/commands/workspace_test.dart
@@ -11,9 +11,9 @@ import '../../../../helpers/helpers.dart';
 
 class _MockLogger extends Mock implements Logger {}
 
-class _MockProgress extends Mock implements Progress {}
-
 class _MockMasonGenerator extends Mock implements MasonGenerator {}
+
+class _MockProgress extends Mock implements Progress {}
 
 class _MockGeneratorHooks extends Mock implements GeneratorHooks {}
 
@@ -26,15 +26,13 @@ class _FakeDirectoryGeneratorTarget extends Fake
 
 final expectedUsage = [
   '''
-Generate a Very Good App UI package.
+Generate a Very Good multi-package workspace.
 
-Usage: very_good create app_ui_package <project-name> [arguments]
+Usage: very_good create workspace <project-name> [arguments]
 -h, --help                Print this usage information.
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
-    --[no-]workspace      Register the new package in the surrounding pub workspace.
-    --publishable         Whether the generated project is intended to be published.
 
 Run "very_good help" to see global options.''',
 ];
@@ -43,6 +41,7 @@ const pubspec = '''
 name: example
 environment:
   sdk: ^3.12.0
+workspace: []
 ''';
 
 void main() {
@@ -64,27 +63,28 @@ void main() {
   group('can be instantiated', () {
     test('with default options', () {
       final logger = Logger();
-      final command = CreateAppUiPackage(
+      final command = CreateWorkspace(
         logger: logger,
         generatorFromBundle: null,
       );
-      expect(command.name, equals('app_ui_package'));
+      expect(command.name, equals('workspace'));
+      expect(command.aliases, equals(['ws']));
       expect(
         command.description,
-        equals('Generate a Very Good App UI package.'),
+        equals('Generate a Very Good multi-package workspace.'),
       );
       expect(command.logger, equals(logger));
-      expect(command, isA<Publishable>());
+      expect(command.registersInWorkspace, isFalse);
     });
   });
 
-  group('create app_ui_package', () {
+  group('create workspace', () {
     test(
       'help',
       withRunner((commandRunner, logger, pubUpdater, printLogs) async {
         final result = await commandRunner.run([
           'create',
-          'app_ui_package',
+          'workspace',
           '--help',
         ]);
         expect(printLogs, equals(expectedUsage));
@@ -92,11 +92,7 @@ void main() {
 
         printLogs.clear();
 
-        final resultAbbr = await commandRunner.run([
-          'create',
-          'app_ui_pkg',
-          '-h',
-        ]);
+        final resultAbbr = await commandRunner.run(['create', 'ws', '-h']);
         expect(printLogs, equals(expectedUsage));
         expect(resultAbbr, equals(ExitCode.success.code));
       }),
@@ -104,7 +100,7 @@ void main() {
 
     group('running the command', () {
       final generatedFiles = List.filled(
-        10,
+        6,
         const GeneratedFile.created(path: ''),
       );
 
@@ -122,27 +118,8 @@ void main() {
             onVarsChanged: any(named: 'onVarsChanged'),
           ),
         ).thenAnswer((_) async {});
-
-        when(
-          () => generator.generate(
-            any(),
-            vars: any(named: 'vars'),
-            logger: any(named: 'logger'),
-          ),
-        ).thenAnswer((_) async {
-          return generatedFiles;
-        });
-
         when(() => generator.id).thenReturn('generator_id');
         when(() => generator.description).thenReturn('generator description');
-        when(() => generator.hooks).thenReturn(hooks);
-
-        when(
-          () => hooks.preGen(
-            vars: any(named: 'vars'),
-            onVarsChanged: any(named: 'onVarsChanged'),
-          ),
-        ).thenAnswer((_) async {});
         when(
           () => generator.generate(
             any(),
@@ -159,49 +136,38 @@ void main() {
         });
       });
 
-      test('creates app ui package', () async {
+      test('creates workspace', () async {
         final tempDirectory = Directory.systemTemp.createTempSync();
         addTearDown(() => tempDirectory.deleteSync(recursive: true));
 
         final argResults = _MockArgResults();
-        final command = CreateAppUiPackage(
+        final command = CreateWorkspace(
           logger: logger,
           generatorFromBundle: (_) async => generator,
         )..argResultOverrides = argResults;
         when(
           () => argResults['output-directory'] as String?,
         ).thenReturn(tempDirectory.path);
-        when(() => argResults.rest).thenReturn(['my_app_ui']);
+        when(() => argResults.rest).thenReturn(['my_workspace']);
 
         final result = await command.run();
 
-        expect(command.template.name, 'app_ui');
+        expect(command.template.name, 'workspace');
         expect(result, equals(ExitCode.success.code));
 
         verify(() => logger.progress('Bootstrapping')).called(1);
         verify(
-          () => hooks.preGen(
-            vars: <String, dynamic>{
-              'project_name': 'my_app_ui',
-              'description': '',
-              'publishable': false,
-            },
-            onVarsChanged: any(named: 'onVarsChanged'),
-          ),
-        );
-        verify(
           () => generator.generate(
             any(),
             vars: <String, dynamic>{
-              'project_name': 'my_app_ui',
+              'project_name': 'my_workspace',
               'description': '',
-              'publishable': false,
             },
             logger: logger,
           ),
         ).called(1);
         verify(
-          () => logger.info('Created a Very Good App UI Package! 🦄'),
+          () => logger.info('Created a Very Good Workspace! 🦄'),
         ).called(1);
       });
     });

--- a/test/src/commands/create/create_subcommand_test.dart
+++ b/test/src/commands/create/create_subcommand_test.dart
@@ -9,8 +9,13 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:very_good_cli/src/commands/create/commands/create_subcommand.dart';
 import 'package:very_good_cli/src/commands/create/templates/template.dart';
+import 'package:very_good_cli/src/workspace/workspace.dart';
 
 class _MockTemplate extends Mock implements Template {}
+
+class _MockWorkspaceDetector extends Mock implements WorkspaceDetector {}
+
+class _MockWorkspaceIntegrator extends Mock implements WorkspaceIntegrator {}
 
 class _MockLogger extends Mock implements Logger {}
 
@@ -29,11 +34,15 @@ class _FakeDirectoryGeneratorTarget extends Fake
 
 class _FakeDirectory extends Fake implements Directory {}
 
+class _FakeFile extends Fake implements File {}
+
 class _TestCreateSubCommand extends CreateSubCommand {
   _TestCreateSubCommand({
     required this.template,
     required super.logger,
     required super.generatorFromBundle,
+    super.workspaceDetector,
+    super.workspaceIntegrator,
   });
 
   @override
@@ -44,6 +53,19 @@ class _TestCreateSubCommand extends CreateSubCommand {
 
   @override
   final Template template;
+}
+
+class _TestCreateSubCommandNoWorkspace extends _TestCreateSubCommand {
+  _TestCreateSubCommandNoWorkspace({
+    required super.template,
+    required super.logger,
+    required super.generatorFromBundle,
+    super.workspaceDetector,
+    super.workspaceIntegrator,
+  });
+
+  @override
+  bool get registersInWorkspace => false;
 }
 
 class _TestCreateSubCommandWithOrgName extends _TestCreateSubCommand
@@ -102,6 +124,7 @@ void main() {
     registerFallbackValue(_FakeDirectoryGeneratorTarget());
     registerFallbackValue(_FakeLogger());
     registerFallbackValue(_FakeDirectory());
+    registerFallbackValue(_FakeFile());
   });
 
   setUp(() {
@@ -124,6 +147,7 @@ Usage: very_good create create_subcommand <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
 
 Run "runner help" to see global options.''';
 
@@ -168,6 +192,9 @@ Run "runner help" to see global options.''';
                 'A Very Good Project created by Very Good CLI.',
               )
               .having((o) => o.mandatory, 'mandatory', false),
+          'workspace': isA<Option>()
+              .having((o) => o.isFlag, 'isFlag', true)
+              .having((o) => o.defaultsTo, 'defaultsTo', false),
         });
         expect(command.argParser.commands, isEmpty);
       });
@@ -574,6 +601,161 @@ See https://dart.dev/tools/pub/pubspec#name for more information.'''),
       );
     });
   });
+
+  group('workspace registration', () {
+    late Template template;
+    late _MockBundle bundle;
+    late GeneratorHooks hooks;
+    late MasonGenerator generator;
+    late _MockWorkspaceDetector detector;
+    late _MockWorkspaceIntegrator integrator;
+
+    setUp(() {
+      bundle = _MockBundle();
+      when(() => bundle.name).thenReturn('test');
+      when(() => bundle.description).thenReturn('Test bundle');
+      when(() => bundle.version).thenReturn('<bundleversion>');
+      template = _MockTemplate();
+      when(() => template.name).thenReturn('test');
+      when(() => template.bundle).thenReturn(bundle);
+      when(
+        () => template.onGenerateComplete(any(), any()),
+      ).thenAnswer((_) async {});
+
+      hooks = _MockGeneratorHooks();
+      generator = _MockMasonGenerator();
+      when(() => generator.hooks).thenReturn(hooks);
+      when(() => generator.id).thenReturn('generator_id');
+      when(() => generator.description).thenReturn('generator description');
+      when(
+        () => hooks.preGen(
+          vars: any(named: 'vars'),
+          onVarsChanged: any(named: 'onVarsChanged'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => generator.generate(
+          any(),
+          vars: any(named: 'vars'),
+          logger: any(named: 'logger'),
+        ),
+      ).thenAnswer((_) async => generatedFiles);
+
+      detector = _MockWorkspaceDetector();
+      integrator = _MockWorkspaceIntegrator();
+      when(() => integrator.ensureWorkspaceResolution(any())).thenReturn(true);
+    });
+
+    _TestCommandRunner buildRunner({bool registersInWorkspace = true}) {
+      final command = registersInWorkspace
+          ? _TestCreateSubCommand(
+              template: template,
+              logger: logger,
+              generatorFromBundle: (_) async => generator,
+              workspaceDetector: detector,
+              workspaceIntegrator: integrator,
+            )
+          : _TestCreateSubCommandNoWorkspace(
+              template: template,
+              logger: logger,
+              generatorFromBundle: (_) async => generator,
+              workspaceDetector: detector,
+              workspaceIntegrator: integrator,
+            );
+      return _TestCommandRunner(command: command);
+    }
+
+    test('registers the package and logs when inside a workspace', () async {
+      when(
+        () => detector.detect(any()),
+      ).thenReturn(const WorkspaceContext(rootPath: '/ws', members: []));
+      when(
+        () => integrator.addPackage(
+          workspaceRoot: any(named: 'workspaceRoot'),
+          packageDirectory: any(named: 'packageDirectory'),
+        ),
+      ).thenReturn('packages/test_project');
+
+      final result = await buildRunner().run([
+        'create_subcommand',
+        'test_project',
+        '--workspace',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verify(
+        () => integrator.addPackage(
+          workspaceRoot: any(named: 'workspaceRoot'),
+          packageDirectory: any(named: 'packageDirectory'),
+        ),
+      ).called(1);
+      verify(
+        () => logger.info(
+          'Added "packages/test_project" to the workspace at /ws.',
+        ),
+      ).called(1);
+    });
+
+    test('does not log when the package is already a member', () async {
+      when(
+        () => detector.detect(any()),
+      ).thenReturn(const WorkspaceContext(rootPath: '/ws', members: []));
+      when(
+        () => integrator.addPackage(
+          workspaceRoot: any(named: 'workspaceRoot'),
+          packageDirectory: any(named: 'packageDirectory'),
+        ),
+      ).thenReturn(null);
+
+      final result = await buildRunner().run([
+        'create_subcommand',
+        'test_project',
+        '--workspace',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verifyNever(() => logger.info(any(that: contains('Added'))));
+    });
+
+    test('does not register when not inside a workspace', () async {
+      when(() => detector.detect(any())).thenReturn(null);
+
+      final result = await buildRunner().run([
+        'create_subcommand',
+        'test_project',
+        '--workspace',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verifyNever(
+        () => integrator.addPackage(
+          workspaceRoot: any(named: 'workspaceRoot'),
+          packageDirectory: any(named: 'packageDirectory'),
+        ),
+      );
+    });
+
+    test('does not register without the --workspace flag', () async {
+      final result = await buildRunner().run([
+        'create_subcommand',
+        'test_project',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verifyNever(() => detector.detect(any()));
+    });
+
+    test('skips detection when registersInWorkspace is false', () async {
+      final result = await buildRunner(registersInWorkspace: false).run([
+        'create_subcommand',
+        'test_project',
+      ]);
+
+      expect(result, equals(ExitCode.success.code));
+      verifyNever(() => detector.detect(any()));
+    });
+  });
+
   group('OrgName', () {
     const expectedUsage = '''
 Usage: very_good create create_subcommand <project-name> [arguments]
@@ -581,6 +763,7 @@ Usage: very_good create create_subcommand <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --org-name            The organization for this new project.
                           (defaults to "com.example.verygoodcore")
 
@@ -888,6 +1071,7 @@ Usage: very_good create create_subcommand <project-name> [arguments]
 -o, --output-directory             The desired output directory when creating a new project.
     --description                  The description for this new project.
                                    (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace               Register the new package in the surrounding pub workspace.
 -t, --template                     The template used to generate this new project.
 
           [template1] (default)    template1 help
@@ -1059,6 +1243,7 @@ Usage: very_good create create_subcommand <project-name> [arguments]
 -o, --output-directory    The desired output directory when creating a new project.
     --description         The description for this new project.
                           (defaults to "A Very Good Project created by Very Good CLI.")
+    --[no-]workspace      Register the new package in the surrounding pub workspace.
     --publishable         Whether the generated project is intended to be published.
 
 Run "runner help" to see global options.''';

--- a/test/src/commands/create/create_test.dart
+++ b/test/src/commands/create/create_test.dart
@@ -19,6 +19,7 @@ Available subcommands:
   flutter_app       Generate a Very Good Flutter application.
   flutter_package   Generate a Very Good Flutter package.
   flutter_plugin    Generate a Very Good Flutter plugin.
+  workspace         Generate a Very Good multi-package workspace.
 
 Run "very_good help" to see global options.''',
 ];

--- a/test/src/workspace/workspace_context_test.dart
+++ b/test/src/workspace/workspace_context_test.dart
@@ -1,0 +1,25 @@
+import 'package:test/test.dart';
+import 'package:very_good_cli/src/workspace/workspace.dart';
+
+void main() {
+  group('WorkspaceContext', () {
+    test('supports value equality', () {
+      const a = WorkspaceContext(rootPath: '/ws', members: ['packages/a']);
+      const b = WorkspaceContext(rootPath: '/ws', members: ['packages/a']);
+      const c = WorkspaceContext(rootPath: '/other', members: ['packages/a']);
+
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('exposes rootPath and members', () {
+      const context = WorkspaceContext(
+        rootPath: '/ws',
+        members: ['apps/app', 'packages/pkg'],
+      );
+
+      expect(context.rootPath, equals('/ws'));
+      expect(context.members, equals(['apps/app', 'packages/pkg']));
+    });
+  });
+}

--- a/test/src/workspace/workspace_detector_test.dart
+++ b/test/src/workspace/workspace_detector_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:very_good_cli/src/workspace/workspace.dart';
+
+void main() {
+  group('WorkspaceDetector', () {
+    test('can be instantiated at runtime', () {
+      const create = WorkspaceDetector.new;
+      expect(create(), isA<WorkspaceDetector>());
+    });
+
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('vg_ws_detector_');
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    void writePubspec(Directory dir, String contents) {
+      Directory(dir.path).createSync(recursive: true);
+      File(path.join(dir.path, 'pubspec.yaml')).writeAsStringSync(contents);
+    }
+
+    test('returns null when no pubspec is found in any ancestor', () {
+      final nested = Directory(path.join(tempDir.path, 'a', 'b'))
+        ..createSync(recursive: true);
+
+      expect(const WorkspaceDetector().detect(nested), isNull);
+    });
+
+    test('returns null when the nearest pubspec is not a workspace', () {
+      writePubspec(tempDir, 'name: solo\n');
+
+      expect(const WorkspaceDetector().detect(tempDir), isNull);
+    });
+
+    test('detects the workspace from the root directory itself', () {
+      writePubspec(tempDir, '''
+name: my_workspace
+workspace:
+  - packages/a
+  - apps/b
+''');
+
+      final context = const WorkspaceDetector().detect(tempDir);
+
+      expect(context, isNotNull);
+      expect(path.equals(context!.rootPath, tempDir.path), isTrue);
+      expect(context.members, equals(['packages/a', 'apps/b']));
+    });
+
+    test('walks up from a nested directory to the workspace root', () {
+      writePubspec(tempDir, '''
+name: my_workspace
+workspace:
+  - packages/a
+''');
+      final nested = Directory(path.join(tempDir.path, 'packages', 'a', 'lib'))
+        ..createSync(recursive: true);
+
+      final context = const WorkspaceDetector().detect(nested);
+
+      expect(context, isNotNull);
+      expect(path.equals(context!.rootPath, tempDir.path), isTrue);
+    });
+
+    test('skips a member pubspec and resolves to the root', () {
+      writePubspec(tempDir, '''
+name: my_workspace
+workspace:
+  - packages/a
+''');
+      final member = Directory(path.join(tempDir.path, 'packages', 'a'));
+      writePubspec(member, '''
+name: a
+resolution: workspace
+''');
+
+      final context = const WorkspaceDetector().detect(member);
+
+      expect(context, isNotNull);
+      expect(path.equals(context!.rootPath, tempDir.path), isTrue);
+    });
+
+    test('treats a non-list workspace value as no members', () {
+      writePubspec(tempDir, '''
+name: my_workspace
+workspace:
+''');
+
+      final context = const WorkspaceDetector().detect(tempDir);
+
+      expect(context, isNotNull);
+      expect(context!.members, isEmpty);
+    });
+  });
+}

--- a/test/src/workspace/workspace_integrator_test.dart
+++ b/test/src/workspace/workspace_integrator_test.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:very_good_cli/src/workspace/workspace.dart';
+
+void main() {
+  group('WorkspaceIntegrator', () {
+    test('can be instantiated at runtime', () {
+      const create = WorkspaceIntegrator.new;
+      expect(create(), isA<WorkspaceIntegrator>());
+    });
+
+    late Directory root;
+    late File pubspec;
+
+    setUp(() {
+      root = Directory.systemTemp.createTempSync('vg_ws_integrator_');
+      pubspec = File(path.join(root.path, 'pubspec.yaml'));
+    });
+
+    tearDown(() {
+      root.deleteSync(recursive: true);
+    });
+
+    Directory member(String relative) {
+      return Directory(path.join(root.path, path.joinAll(relative.split('/'))));
+    }
+
+    test('adds the first member to an empty list as a block sequence', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace: []
+''');
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('packages/a'),
+      );
+
+      expect(added, equals('packages/a'));
+      expect(
+        pubspec.readAsStringSync(),
+        equals('''
+name: my_workspace
+workspace:
+  - packages/a
+'''),
+      );
+    });
+
+    test('appends a member when the list is not empty', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace:
+  - packages/a
+''');
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('apps/b'),
+      );
+
+      expect(added, equals('apps/b'));
+      expect(pubspec.readAsStringSync(), contains('  - packages/a'));
+      expect(pubspec.readAsStringSync(), contains('  - apps/b'));
+    });
+
+    test('creates the workspace key when it is absent', () {
+      pubspec.writeAsStringSync('name: my_workspace\n');
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('packages/a'),
+      );
+
+      expect(added, equals('packages/a'));
+      expect(pubspec.readAsStringSync(), contains('workspace:'));
+      expect(pubspec.readAsStringSync(), contains('packages/a'));
+    });
+
+    test('treats a null workspace value as an empty list', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace:
+''');
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('packages/a'),
+      );
+
+      expect(added, equals('packages/a'));
+      expect(pubspec.readAsStringSync(), contains('- packages/a'));
+    });
+
+    test('preserves existing comments and formatting', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+# managed automatically
+workspace: []
+''');
+
+      const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('packages/a'),
+      );
+
+      expect(pubspec.readAsStringSync(), contains('# managed automatically'));
+    });
+
+    test('returns null and makes no change when already a member', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace:
+  - packages/a
+''');
+      final before = pubspec.readAsStringSync();
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: member('packages/a'),
+      );
+
+      expect(added, isNull);
+      expect(pubspec.readAsStringSync(), equals(before));
+    });
+
+    test('returns null when the package is the workspace root itself', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace: []
+''');
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: root,
+      );
+
+      expect(added, isNull);
+    });
+
+    test('returns null when the package is outside the workspace root', () {
+      pubspec.writeAsStringSync('''
+name: my_workspace
+workspace: []
+''');
+      final outside = Directory(path.join(root.parent.path, 'elsewhere'));
+
+      final added = const WorkspaceIntegrator().addPackage(
+        workspaceRoot: root,
+        packageDirectory: outside,
+      );
+
+      expect(added, isNull);
+    });
+
+    group('ensureWorkspaceResolution', () {
+      test('adds resolution: workspace when absent', () {
+        pubspec.writeAsStringSync('name: pkg\n');
+
+        final changed = const WorkspaceIntegrator().ensureWorkspaceResolution(
+          pubspec,
+        );
+
+        expect(changed, isTrue);
+        expect(pubspec.readAsStringSync(), contains('resolution: workspace'));
+      });
+
+      test('is a no-op when already declared', () {
+        pubspec.writeAsStringSync('name: pkg\nresolution: workspace\n');
+
+        final changed = const WorkspaceIntegrator().ensureWorkspaceResolution(
+          pubspec,
+        );
+
+        expect(changed, isFalse);
+      });
+
+      test('returns false when the pubspec does not exist', () {
+        final missing = File(path.join(root.path, 'nope', 'pubspec.yaml'));
+        expect(
+          const WorkspaceIntegrator().ensureWorkspaceResolution(missing),
+          isFalse,
+        );
+      });
+    });
+
+    group('addPathDependency', () {
+      test('adds a path dependency under dependencies', () {
+        pubspec.writeAsStringSync('''
+name: app
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+
+        final added = const WorkspaceIntegrator().addPathDependency(
+          appPubspec: pubspec,
+          packageName: 'my_pkg',
+          relativePath: '../../packages/my_pkg',
+        );
+
+        expect(added, isTrue);
+        final content = pubspec.readAsStringSync();
+        expect(content, contains('my_pkg:'));
+        expect(content, contains('path: ../../packages/my_pkg'));
+      });
+
+      test('creates the dependencies map when missing', () {
+        pubspec.writeAsStringSync('name: app\n');
+
+        final added = const WorkspaceIntegrator().addPathDependency(
+          appPubspec: pubspec,
+          packageName: 'my_pkg',
+          relativePath: '../my_pkg',
+        );
+
+        expect(added, isTrue);
+        expect(pubspec.readAsStringSync(), contains('dependencies:'));
+      });
+
+      test('returns false when already a dependency', () {
+        pubspec.writeAsStringSync('''
+name: app
+dependencies:
+  my_pkg:
+    path: ../my_pkg
+''');
+
+        final added = const WorkspaceIntegrator().addPathDependency(
+          appPubspec: pubspec,
+          packageName: 'my_pkg',
+          relativePath: '../my_pkg',
+        );
+
+        expect(added, isFalse);
+      });
+    });
+  });
+}

--- a/tool/generate_bundles.sh
+++ b/tool/generate_bundles.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Runs `mason bundle` to generate bundles for all bricks within the respective templates directories.
 
+# Brick sources live in the `VeryGoodOpenSource/very_good_templates` repository
+# and are published to brickhub.dev. Only the generated bundles are committed
+# here. See CONTRIBUTING.md.
 bricks=(
     very_good_app_ui
     very_good_core
@@ -10,6 +13,7 @@ bricks=(
     very_good_flutter_plugin
     very_good_flame_game
     very_good_docs_site
+    very_good_workspace
 )
 
 for brick in "${bricks[@]}"


### PR DESCRIPTION
<!--
PR title: feat(create): add pub workspace support
-->

## Status

**READY**

## Description

Adds first-class support for [pub workspaces](https://dart.dev/tools/pub/workspaces).

- **New command `very_good create workspace <name>`** scaffolds a multi-package
  workspace: a root `pubspec.yaml` with a `workspace:` list plus `apps/` and
  `packages/` directories for members.
- **New opt-in `--workspace` flag** on every `create` subcommand. When run inside
  a workspace it (a) registers the generated package in the root `workspace:`
  list and (b) writes `resolution: workspace` into the member, so the workspace
  resolves without a manual edit. It defaults to off and is a no-op outside a
  workspace, so existing behavior is unchanged.
- **Shared infrastructure** in `lib/src/workspace/` (`WorkspaceContext`,
  `WorkspaceDetector`, `WorkspaceIntegrator`) that later workspace-aware commands
  build on. Adds the `yaml_edit` dependency.
- The `create` MCP tool gains `workspace` as a subcommand option.
- Docs: README (a "🆕 Multi-package workspaces" callout plus a dedicated
  **Workspaces** subsection under `create`), `site/docs/commands/create.md`,
  `overview.md`, and `doc/mcp.md`.

Fully additive and behind an opt-in flag. The full test suite is green, the
analyzer/formatter are clean, and 100% coverage is maintained.

> Note: per VGV convention the brick *source* lives in `very_good_templates`;
> this PR commits only the generated bundle. If preferred, the brick can be
> published there first and the bundle regenerated against it.

## New commands

`very_good create workspace <name>` — scaffold a pub workspace (a `create` subcommand):

```sh
# Create the workspace
very_good create workspace my_workspace

# Add members from inside it (registers them + sets resolution: workspace)
cd my_workspace
very_good create dart_package my_package -o packages --workspace
very_good create flutter_app  my_app     -o apps     --workspace
```

The `--workspace` / `--no-workspace` flag is available on every `create`
subcommand and defaults to off.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore


## Video/Screenshot

https://github.com/user-attachments/assets/63abbfe6-6e51-4be8-948d-59818f7c3be6



<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/f6005d5b-6ebe-4dd4-9f9e-a6b0a7259b10" />

